### PR TITLE
switch from member function binding to multiple inheritance for filtering

### DIFF
--- a/filters/exponential_moving_average.cpp
+++ b/filters/exponential_moving_average.cpp
@@ -49,9 +49,14 @@ namespace serenity {
 
 ExponentialMovingAverageFilter::~ExponentialMovingAverageFilter() {}
 
-Try<int> ExponentialMovingAverageFilter::doWork(int in)
+Try<int> ExponentialMovingAverageFilter::handle(int in)
 {
   return in;
+}
+
+Try<Nothing> ExponentialMovingAverageFilter::input(int in)
+{
+  return Nothing();
 }
 
 } // namespace serenity

--- a/filters/exponential_moving_average.hpp
+++ b/filters/exponential_moving_average.hpp
@@ -51,19 +51,17 @@ namespace serenity {
 
 
 //TODO: Template it <IN, OUT> and add a strategy to constructor?
-class ExponentialMovingAverageFilter : public Filter<int, int>
+class ExponentialMovingAverageFilter : public FilterIn<int>, public FilterOut<int>
 {
 public:
 
   ExponentialMovingAverageFilter(){}; //test constructor
-
-  template <typename ...Any>
-  ExponentialMovingAverageFilter(Filter<int, Any>*... outputFilters) : Filter(outputFilters...) {};
-
   ~ExponentialMovingAverageFilter() noexcept;
 
+  Try<Nothing> input(int in);
+
 protected:
-  virtual Try<int> doWork(int in) override;
+  Try<int> handle(int in);
 
 private:
   ExponentialMovingAverageFilter(ExponentialMovingAverageFilter& other) {};

--- a/filters/moving_average.cpp
+++ b/filters/moving_average.cpp
@@ -49,7 +49,12 @@ namespace serenity {
 
 MovingAverageFilter::~MovingAverageFilter() {}
 
-Try<int> MovingAverageFilter::doWork(int in)
+Try<Nothing> MovingAverageFilter::input(int in)
+{
+  return Nothing();
+}
+
+Try<int> MovingAverageFilter::handle(int in)
 {
   return in;
 }

--- a/filters/moving_average.hpp
+++ b/filters/moving_average.hpp
@@ -50,18 +50,16 @@
 namespace mesos {
 namespace serenity {
 
-//TODO: Template it <IN, OUT> and add a strategy to constructor?
-class MovingAverageFilter : public Filter<int, int>
+class MovingAverageFilter : public FilterIn<int>, public FilterOut<int>
 {
 public:
-
-  template <typename ...Any>
-  MovingAverageFilter(Filter<int, Any>*... outputFilters) : Filter(outputFilters...) {};
-
+  MovingAverageFilter() {}
   ~MovingAverageFilter() noexcept;
 
+  Try<Nothing> input(int in);
+
 protected:
-  virtual Try<int> doWork(int in) override;
+  Try<int> handle(int in);
 
 private:
   MovingAverageFilter(MovingAverageFilter& other) {};

--- a/pipeline/pipeline_test.cpp
+++ b/pipeline/pipeline_test.cpp
@@ -2,9 +2,9 @@
 
 #include <stout/try.hpp>
 
-#include "filters/moving_average.hpp"
-#include "filters/exponential_moving_average.hpp"
-#include "qos_controllers/serenity_qos_controller.hpp"
+#include "filters/moving_average.cpp"
+#include "filters/exponential_moving_average.cpp"
+#include "qos_controllers/serenity_qos_controller.cpp"
 
 #include "messages/serenity.hpp"
 
@@ -15,19 +15,17 @@ int main(int argc, char** argv)
   std::cout << "pipe test" << "\n";
 
 
+  mesos::serenity::MovingAverageFilter defFilter;
+  mesos::serenity::ExponentialMovingAverageFilter expFilter;
+  expFilter.bind(&defFilter);
+  defFilter.input(0);
+  defFilter.send(0);
+
   mesos::serenity::SerenityQoSController qos;
+  defFilter.bind(&qos);
 
-//  mesos::serenity::MovingAverageFilter defFilter;
-//  mesos::serenity::ExponentialMovingAverageFilter expFilter(&defFilter);
-
-//  mesos::serenity::MovingAverageFilter defFilter2(defFilter);
-//  mesos::serenity::MovingAverageFilter mafilter
-
-  mesos::serenity::MovingAverageFilter mafilter3(&qos);
-
-  mesos::serenity::MovingAverageFilter mafilter2(&qos, &qos);
-
-  mesos::serenity::MovingAverageFilter mafilter4(&qos, &mafilter3);
+  // Copy contructor?
+  //mesos::serenity::MovingAverageFilter defFilter2(defFilter);
 
   return EXIT_SUCCESS;
 }

--- a/qos_controllers/serenity_qos_controller.cpp
+++ b/qos_controllers/serenity_qos_controller.cpp
@@ -46,11 +46,10 @@
 namespace mesos {
 namespace serenity {
 
-SerenityQoSController::~SerenityQoSController() {};
+SerenityQoSController::~SerenityQoSController() {}
 
-
-Try<None> SerenityQoSController::doWork(int in) {
-  return None();
+Try<Nothing> SerenityQoSController::input(int in) {
+  return Nothing();
 }
 
 } // namespace serenity

--- a/qos_controllers/serenity_qos_controller.hpp
+++ b/qos_controllers/serenity_qos_controller.hpp
@@ -45,6 +45,7 @@
 #define SERENITY_SERENITY_QOS_CONTROLLER_HPP
 
 #include <stout/nothing.hpp>
+#include <stout/none.hpp>
 #include <stout/try.hpp>
 
 #include "serenity/serenity.hpp"
@@ -52,14 +53,16 @@
 namespace mesos {
 namespace serenity {
 
-class SerenityQoSController : public Sink<int>
+class SerenityQoSController : public FilterIn<int>
 {
 public:
   SerenityQoSController() {};
   ~SerenityQoSController() noexcept;
 
+  Try<Nothing> input(int in);
+
 protected:
-  Try<None> doWork(int in) override;
+  Try<None> handle(int in);
 
 };
 

--- a/sources/dummy_source.hpp
+++ b/sources/dummy_source.hpp
@@ -53,11 +53,11 @@
 namespace mesos {
 namespace serenity {
 
-class DummySource : Source<int>
+class DummySource : FilterOut<int>
 {
 public:
   template <typename ...Any>
-  DummySource(Filter<int, Any>*... outputFilters) : Filter(outputFilters...) {};
+  DummySource() {}
 
   ~DummySource() noexcept;
 


### PR DESCRIPTION
Each filter or member of the pipeline can now inherit from from
FilterIn, FilterOut or both.  Having the ::input signature decoupled
from the ::send allows for a simpler interface for disparate base Filter
types.  This commit also adds the gitignore, and cleans up the
pipeline_test.cpp file.

The outputs of avg are disparate types, and with the method found in this commit, these bindings can work through the inheritance of multiple interfaces, and then slicing the behavior up as needed.  This is achievable because the outputs of a given node in the filter will always be the same as _at least_ the inputs of the next node in the chain.

Take the example:
```
        (RS,int)            (int, correction)
slave----> avg -----------> QoS
              |
              (int, int)    (int, correction)
              avg2 -------> Estimator
```
This allows avg to have both the types QoS and avg2 bound to its output without having to worry about what _their_ outputs are.