### PR TITLE
Added missing math.h include

### DIFF
--- a/filters/ema.hpp
+++ b/filters/ema.hpp
@@ -1,6 +1,8 @@
 #ifndef SERENITY_EXPONENTIAL_MOVING_AVERAGE_HPP
 #define SERENITY_EXPONENTIAL_MOVING_AVERAGE_HPP
 
+#include <math.h>
+
 #include "messages/serenity.hpp"
 
 #include "serenity/serenity.hpp"


### PR DESCRIPTION
Clang build failed with:

```
[ 30%] Building CXX object CMakeFiles/serenity.dir/filters/ema.cpp.o
In file included from /Users/niklas/scratchpad/serenity/filters/ema.cpp:1:
/Users/niklas/scratchpad/serenity/filters/ema.hpp:68:21: error: use of undeclared identifier 'exp'
    double weight = exp(dynamic_alpha * -1);
                    ^
1 error generated.
make[2]: *** [CMakeFiles/serenity.dir/filters/ema.cpp.o] Error 1
make[1]: *** [CMakeFiles/serenity.dir/all] Error 2
make: *** [all] Error 2
```