### PR TITLE
Added test-framework to serenity cmake list.(MOO-34)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,3 +89,22 @@ target_link_libraries(serenity-tests
     serenity
 )
 add_test(serenity-tests serenity-tests)
+
+# For framework compilation we need mesos_source.
+# Test framework resuses utility classes from apache mesos.
+SET(WITH_SOURCE_MESOS "" CACHE STRING "Mesos source directory")
+SET(MESOS_SOURCE_DIR ${WITH_SOURCE_MESOS})
+
+if (MESOS_SOURCE_DIR)
+    MESSAGE("Mesos source directory set to: " ${MESOS_SOURCE_DIR})
+
+    include_directories(
+        ${MESOS_SOURCE_DIR}/build/src/
+        ${MESOS_SOURCE_DIR}/src/
+    )
+    # Serenity test framework exe.
+    add_executable(test-framework
+        ${MESOS_SOURCE_DIR}/src/examples/no_executor_framework.cpp)
+    target_link_libraries(test-framework mesos glog)
+
+endif(MESOS_SOURCE_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,9 @@ target_link_libraries(serenity-tests
 )
 add_test(serenity-tests serenity-tests)
 
-# For framework compilation we need mesos_source.
-# Test framework resuses utility classes from apache mesos.
+# For our smoke-test-framework we use NoExecutorFramework
+# which is sufficient for us. It requires mesos source directory.
+# If WITH_SOURCE_MESOS is not specify, test-framework is omitted.
 SET(WITH_SOURCE_MESOS "" CACHE STRING "Mesos source directory")
 SET(MESOS_SOURCE_DIR ${WITH_SOURCE_MESOS})
 
@@ -107,4 +108,8 @@ if (MESOS_SOURCE_DIR)
         ${MESOS_SOURCE_DIR}/src/examples/no_executor_framework.cpp)
     target_link_libraries(test-framework mesos glog)
 
+else(MESOS_SOURCE_DIR)
+    MESSAGE(
+        "Mesos source directory was not set. "
+        "Test-framework compilation will be omitted.")
 endif(MESOS_SOURCE_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ add_test(serenity-tests serenity-tests)
 
 # For our smoke-test-framework we use NoExecutorFramework
 # which is sufficient for us. It requires mesos source directory.
-# If WITH_SOURCE_MESOS is not specify, test-framework is omitted.
+# If WITH_SOURCE_MESOS is not specified, test-framework is omitted.
 SET(WITH_SOURCE_MESOS "" CACHE STRING "Mesos source directory")
 SET(MESOS_SOURCE_DIR ${WITH_SOURCE_MESOS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if (MESOS_SOURCE_DIR)
     # Serenity test framework exe.
     add_executable(test-framework
         ${MESOS_SOURCE_DIR}/src/examples/no_executor_framework.cpp)
-    target_link_libraries(test-framework mesos glog)
+    target_link_libraries(test-framework mesos protobuf glog)
 
 else(MESOS_SOURCE_DIR)
     MESSAGE(

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN rm -rf build && \
     mkdir build && \
     cd build && \
     export LD_LIBRARY_PATH=LD_LIBRARY_PATH:/usr/local/lib && \
-    cmake -DWITH_MESOS="/mesos" .. && \
+    cmake -DWITH_MESOS="/mesos" -DWITH_SOURCE_MESOS="/mesos" .. && \
     make -j 2 && \
     ./serenity-tests


### PR DESCRIPTION
- It can be optionally built when mesos source dir is specified.
- NoExecutorFramework is used. It is sufficient for us. It is already aware of revocable resources.