### PR TITLE
Pipeline improvement v1

### DIFF
--- a/estimator/serenity_estimator.cpp
+++ b/estimator/serenity_estimator.cpp
@@ -35,6 +35,12 @@ class SerenityEstimatorProcess :
 
   Future<Resources> _oversubscribable(
       const Future<ResourceUsage>& _resourceUsage) {
+    // TODO(bplotka): Decide if need such simple algorithm.
+    Resources allocatedRevocable;
+    foreach(auto& executor, _resourceUsage.get().executors()) {
+      allocatedRevocable += Resources(executor.allocated()).revocable();
+    }
+
     Result<Resources> ret = this->pipeline->run(_resourceUsage.get());
 
     if (ret.isError()) {
@@ -44,7 +50,7 @@ class SerenityEstimatorProcess :
       return Resources();
     }
 
-    return ret.get();
+    return ret.get() - allocatedRevocable;
   }
 
  private:

--- a/estimator/serenity_estimator.cpp
+++ b/estimator/serenity_estimator.cpp
@@ -49,8 +49,8 @@ class SerenityEstimatorProcess :
     } else if (ret.isNone()) {
       return Resources();
     }
-
-    return ret.get() - allocatedRevocable;
+    LOG(INFO) << allocatedRevocable;
+    return (ret.get() - allocatedRevocable);
   }
 
  private:

--- a/estimator/serenity_estimator.cpp
+++ b/estimator/serenity_estimator.cpp
@@ -49,7 +49,8 @@ class SerenityEstimatorProcess :
     } else if (ret.isNone()) {
       return Resources();
     }
-    LOG(INFO) << allocatedRevocable;
+    LOG(INFO) << "[Serenity] Considering allocated revocable resources: "
+              << allocatedRevocable;
     return (ret.get() - allocatedRevocable);
   }
 

--- a/estimator/serenity_estimator.cpp
+++ b/estimator/serenity_estimator.cpp
@@ -35,7 +35,6 @@ class SerenityEstimatorProcess :
 
   Future<Resources> _oversubscribable(
       const Future<ResourceUsage>& _resourceUsage) {
-    // TODO(bplotka): Decide if need such simple algorithm.
     Resources allocatedRevocable;
     foreach(auto& executor, _resourceUsage.get().executors()) {
       allocatedRevocable += Resources(executor.allocated()).revocable();

--- a/estimator/serenity_estimator.cpp
+++ b/estimator/serenity_estimator.cpp
@@ -35,10 +35,12 @@ class SerenityEstimatorProcess :
 
   Future<Resources> _oversubscribable(
       const Future<ResourceUsage>& _resourceUsage) {
-    Try<Resources> ret = this->pipeline->run(_resourceUsage.get());
+    Result<Resources> ret = this->pipeline->run(_resourceUsage.get());
 
     if (ret.isError()) {
       LOG(ERROR) << ret.error();
+      return Resources();
+    } else if (ret.isNone()) {
       return Resources();
     }
 

--- a/filters/utilization_threshold.cpp
+++ b/filters/utilization_threshold.cpp
@@ -85,6 +85,11 @@ Try<Nothing> UtilizationThresholdFilter::consume(const ResourceUsage& product) {
   this->previousSamples->clear();
   this->previousSamples = std::move(newSamples);
 
+  if (this->previousSamples->empty()) {
+    LOG(INFO) << name << "No Executor in Usage.";
+    return Nothing();
+  }
+
   Resources totalSlaveResources(product.total());
   Option<double_t> totalSlaveCpus = totalSlaveResources.cpus();
   if (totalSlaveCpus.isSome() && this->previousSamples->size() > 0) {

--- a/filters/utilization_threshold.cpp
+++ b/filters/utilization_threshold.cpp
@@ -86,6 +86,7 @@ Try<Nothing> UtilizationThresholdFilter::consume(const ResourceUsage& product) {
   this->previousSamples = std::move(newSamples);
 
   if (this->previousSamples->empty()) {
+    // Don't log it in real env.
     LOG(INFO) << name << "No Executor in Usage.";
     return Nothing();
   }

--- a/filters/utilization_threshold.cpp
+++ b/filters/utilization_threshold.cpp
@@ -86,8 +86,8 @@ Try<Nothing> UtilizationThresholdFilter::consume(const ResourceUsage& product) {
   this->previousSamples = std::move(newSamples);
 
   if (this->previousSamples->empty()) {
-    // Don't log it in real env.
-    LOG(INFO) << name << "No Executor in Usage.";
+    LOG(INFO) << name
+              << "There is no Executor in given usage. Ending the pipeline.";
     return Nothing();
   }
 

--- a/filters/valve.cpp
+++ b/filters/valve.cpp
@@ -222,7 +222,7 @@ Try<Nothing> ValveFilter::consume(const ResourceUsage& in) {
     LOG(INFO) << ValveFilter::name
               << (this->valveType == RESOURCE_ESTIMATOR_VALVE?
                   "Estimator ":
-                  "QoSController")
+                  "QoSController ")
               << "pipeline is closed";
   }
 

--- a/filters/valve.cpp
+++ b/filters/valve.cpp
@@ -201,7 +201,8 @@ ValveFilter::ValveFilter(
     ValveType _valveType,
     bool _opened)
   : Producer<ResourceUsage>(_consumer),
-    process(new ValveFilterEndpointProcess(_valveType, _opened)) {
+    process(new ValveFilterEndpointProcess(_valveType, _opened)),
+    valveType(_valveType) {
   isOpened = process.get()->getIsOpenedFunction();
   spawn(process.get());
 }
@@ -217,8 +218,12 @@ Try<Nothing> ValveFilter::consume(const ResourceUsage& in) {
   if (this->isOpened().get()) {
     this->produce(in);
   } else {
-    LOG(INFO) << ValveFilter::name << "Pipeline is closed";
-    // Currently we are stopping pipeline in case of blocker.
+    // Currently we are not continuing pipeline in case of closed valve.
+    LOG(INFO) << ValveFilter::name
+              << (this->valveType == RESOURCE_ESTIMATOR_VALVE?
+                  "Estimator ":
+                  "QoSController")
+              << "pipeline is closed";
   }
 
   return Nothing();

--- a/filters/valve.hpp
+++ b/filters/valve.hpp
@@ -62,6 +62,7 @@ class ValveFilter :
  private:
   lambda::function<process::Future<bool>()> isOpened;
   process::Owned<ValveFilterEndpointProcess> process;
+  ValveType valveType;
 };
 
 }  // namespace serenity

--- a/observers/slack_resource.cpp
+++ b/observers/slack_resource.cpp
@@ -42,6 +42,7 @@ Try<Nothing> SlackResourceObserver::consume(const ResourceUsage& usage) {
   cpuSlackScalar->set_value(cpuSlack);
 
   slackResult.set_name("cpus");
+  slackResult.set_role(this->default_role);
   slackResult.set_type(Value::SCALAR);
   slackResult.set_allocated_scalar(cpuSlackScalar);
   slackResult.set_allocated_revocable(new Resource_RevocableInfo());

--- a/observers/slack_resource.cpp
+++ b/observers/slack_resource.cpp
@@ -26,6 +26,9 @@ Try<Nothing> SlackResourceObserver::consume(const ResourceUsage& usage) {
         Result<double_t> slackResource = CalculateCpuSlack(
             (*previousSample), executor);
         if (slackResource.isSome()) {
+            LOG(INFO) << this->name << "Estimated revocable resources for "
+                      << executor.executor_info().name() << ": "
+                      << slackResource.get();
             cpuSlack += slackResource.get();
         } else if (slackResource.isError()) {
           LOG(ERROR) << slackResource.error();

--- a/observers/slack_resource.cpp
+++ b/observers/slack_resource.cpp
@@ -27,7 +27,8 @@ Try<Nothing> SlackResourceObserver::consume(const ResourceUsage& usage) {
             (*previousSample), executor);
         if (slackResource.isSome()) {
             LOG(INFO) << this->name << "Estimated revocable resources for "
-                      << executor.executor_info().name() << ": "
+                      << executor.executor_info().name() << " FrameworkID("
+                      << executor.executor_info().framework_id() << "): "
                       << slackResource.get();
             cpuSlack += slackResource.get();
         } else if (slackResource.isError()) {

--- a/observers/slack_resource.hpp
+++ b/observers/slack_resource.hpp
@@ -17,6 +17,17 @@
 namespace mesos {
 namespace serenity {
 
+// TODO(bplotka): Make default role configurable from another source
+// (not only env)and as a default pass *
+inline std::string getDefaultRole() {
+  if (const char* env = std::getenv("MESOS_DEFAULT_ROLE")) {
+    return env;
+  } else {
+    return "*";
+  }
+}
+
+
 /**
  * SlackResourceObserver observes incoming ResourceUsage
  * and produces Resource with revocable flag set (Slack Resources).
@@ -26,11 +37,13 @@ namespace serenity {
 class SlackResourceObserver : public Consumer<ResourceUsage>,
                               public Producer<Resources> {
  public:
-  SlackResourceObserver() : previousSamples(new ExecutorSet()) {}
+  SlackResourceObserver()
+      : previousSamples(new ExecutorSet()), default_role(getDefaultRole()) {}
 
   explicit SlackResourceObserver(Consumer<Resources>* _consumer)
     : Producer<Resources>(_consumer),
-      previousSamples(new ExecutorSet()) {}
+      previousSamples(new ExecutorSet()),
+      default_role(getDefaultRole()) {}
 
   ~SlackResourceObserver() {}
 
@@ -49,7 +62,9 @@ class SlackResourceObserver : public Consumer<ResourceUsage>,
   static constexpr double_t SLACK_EPSILON = 0.001;
 
  private:
-  SlackResourceObserver(const SlackResourceObserver& other){}
+  SlackResourceObserver(const SlackResourceObserver& other)
+      : default_role(getDefaultRole()) {}
+  std::string default_role;
 };
 
 }  // namespace serenity

--- a/observers/slack_resource.hpp
+++ b/observers/slack_resource.hpp
@@ -36,7 +36,7 @@ class SlackResourceObserver : public Consumer<ResourceUsage>,
 
   Try<Nothing> consume(const ResourceUsage& usage) override;
 
-  static constexpr const char* name = "[Serenity] SlackObservers: ";
+  static constexpr const char* name = "[Serenity] SlackObserver: ";
 
  protected:
   Result<double_t> CalculateCpuSlack(const ResourceUsage_Executor& prev,

--- a/observers/slack_resource.hpp
+++ b/observers/slack_resource.hpp
@@ -22,9 +22,8 @@ namespace serenity {
 inline std::string getDefaultRole() {
   if (const char* env = std::getenv("MESOS_DEFAULT_ROLE")) {
     return env;
-  } else {
-    return "*";
   }
+  return "*";
 }
 
 

--- a/pipeline/estimator_pipeline.hpp
+++ b/pipeline/estimator_pipeline.hpp
@@ -64,8 +64,10 @@ class CpuEstimatorPipeline : public ResourceEstimatorPipeline {
       // First item in pipeline.
       valveFilter(ValveFilter(
           &utilizationFilter, ValveType::RESOURCE_ESTIMATOR_VALVE)) {
+    // NOTE(bplotka): Currently we wait one minute for testing purposes.
+    // However in production env 5 minutes is a better value.
+    this->ignoreNewExecutorsFilter.setThreshold(60);
     // Setup beginning producer.
-    this->ignoreNewExecutorsFilter.setThreshold(60);  // One minute.
     this->addConsumer(&valveFilter);
   }
 

--- a/pipeline/estimator_pipeline.hpp
+++ b/pipeline/estimator_pipeline.hpp
@@ -65,6 +65,7 @@ class CpuEstimatorPipeline : public ResourceEstimatorPipeline {
       valveFilter(ValveFilter(
           &utilizationFilter, ValveType::RESOURCE_ESTIMATOR_VALVE)) {
     // Setup beginning producer.
+    this->ignoreNewExecutorsFilter.setThreshold(60);  // One minute.
     this->addConsumer(&valveFilter);
   }
 

--- a/pipeline/pipeline.hpp
+++ b/pipeline/pipeline.hpp
@@ -4,8 +4,9 @@
 #include "serenity/serenity.hpp"
 
 #include "stout/error.hpp"
-#include "stout/try.hpp"
 #include "stout/nothing.hpp"
+#include "stout/result.hpp"
+#include "stout/try.hpp"
 
 namespace mesos {
 namespace serenity {
@@ -24,7 +25,7 @@ class Pipeline : public Producer<Product>, public Consumer<Consumable> {
  public:
   virtual ~Pipeline() {}
 
-  virtual Try<Consumable> run(const Product& _product) {
+  virtual Result<Consumable> run(const Product& _product) {
     // Reset result.
     this->result = None();
 
@@ -34,16 +35,7 @@ class Pipeline : public Producer<Product>, public Consumer<Consumable> {
       return Error(ret.error());
     }
 
-    // Proper pipeline should fill result at the end.
-    // (run this->consume(..))
-    if (this->result.isNone()) {
-      // End of pipeline did not consume anything.
-      return Error(
-          "[Serenity] Pipeline is blocked - haven't got any "
-              "consumable from pipeline.");
-    }
-
-    return this->result.get();
+    return this->result;
   }
 
   virtual Try<Nothing> consume(const Consumable& in) {

--- a/qos_controller/serenity_controller.cpp
+++ b/qos_controller/serenity_controller.cpp
@@ -62,13 +62,13 @@ class SerenityControllerProcess :
 
   QoSCorrections __corrections(
       const Future<ResourceUsage>& _resourceUsage) {
-    Try<QoSCorrections> ret = this->pipeline->run(_resourceUsage.get());
+    Result<QoSCorrections> ret = this->pipeline->run(_resourceUsage.get());
 
     QoSCorrections corrections;
     if (ret.isError()) {
       LOG(ERROR) << ret.error();
       // Return empty corrections.
-    } else {
+    } else if (ret.isSome()) {
       corrections = ret.get();
     }
     return corrections;

--- a/tests/controllers/qos_controller_test.cpp
+++ b/tests/controllers/qos_controller_test.cpp
@@ -31,7 +31,7 @@ class TestCorrectionPipeline : public QoSControllerPipeline {
  public:
   TestCorrectionPipeline() {}
 
-  virtual Try<QoSCorrections> run(const ResourceUsage& _product) {
+  virtual Result<QoSCorrections> run(const ResourceUsage& _product) {
     QoSCorrections corrections;
 
     ExecutorInfo executorInfo;

--- a/tests/estimators/estimator_test.cpp
+++ b/tests/estimators/estimator_test.cpp
@@ -26,7 +26,7 @@ class TestEstimationPipeline : public ResourceEstimatorPipeline {
  public:
   TestEstimationPipeline() {}
 
-  virtual Try<Resources> run(const ResourceUsage& _product) {
+  virtual Result<Resources> run(const ResourceUsage& _product) {
     return Resources::parse("cpus(*):16");
   }
 };

--- a/tests/pipeline/estimator_pipeline_test.cpp
+++ b/tests/pipeline/estimator_pipeline_test.cpp
@@ -31,8 +31,8 @@ TEST(EstimatorPipelineTest, FiltersNotProperlyFed) {
 
   ResourceEstimatorPipeline* pipeline = new CpuEstimatorPipeline();
 
-  Try<Resources> slack = pipeline->run(usage);
-  EXPECT_ERROR(slack);
+  Result<Resources> slack = pipeline->run(usage);
+  EXPECT_NONE(slack);
 
   delete pipeline;
 }
@@ -50,7 +50,7 @@ TEST(EstimatorPipelineTest, NoSlack) {
 
   ResourceEstimatorPipeline* pipeline = new CpuEstimatorPipeline();
 
-  Try<Resources> slack = pipeline->run(usage);
+  Result<Resources> slack = pipeline->run(usage);
   ASSERT_SOME(slack);
 
   EXPECT_TRUE(slack.get().empty());

--- a/tests/pipeline/qos_pipeline_test.cpp
+++ b/tests/pipeline/qos_pipeline_test.cpp
@@ -40,8 +40,8 @@ TEST(QoSPipelineTest, FiltersNotProperlyFed) {
             CONTENTION_COOLDOWN,
             RELATIVE_THRESHOLD));
 
-  Try<QoSCorrections> corrections = pipeline->run(usage);
-  EXPECT_ERROR(corrections);
+  Result<QoSCorrections> corrections = pipeline->run(usage);
+  EXPECT_NONE(corrections);
 
   delete pipeline;
 }


### PR DESCRIPTION
- *!* Considering revocable allocation in estimation.
- Changed pipeline behavior if no result is present in source. (Previously it was an error -> now is just an empty Result<>)
- Added info logs to slack observer.
- Changed IgnoreNewExecutorThreshold to 1 min.
- Each resource is now pinned to some role which is fetched from MESOS_DEFAULT_ROLE env variable. If not defined than '*' is used.
