### PR TITLE
Removed use of <regex> header which is unsupported in GCC 4.8.3

### DIFF
--- a/serenity/os_utils.hpp
+++ b/serenity/os_utils.hpp
@@ -1,10 +1,13 @@
 #ifndef SERENITY_OS_UTILS_HPP
 #define SERENITY_OS_UTILS_HPP
 
+#include <unistd.h>
 #include <string>
 
 #include "stout/none.hpp"
 #include "stout/option.hpp"
+#include "stout/try.hpp"
+
 
 namespace mesos {
 namespace serenity {
@@ -15,6 +18,17 @@ inline static Option<std::string> GetEnviromentVariable(
     return env;
   }
   return None();
+}
+
+inline static Try<std::string> GetHostname() {
+  constexpr size_t BUF_SIZE = 32;
+  char buf[BUF_SIZE];
+
+  int result = gethostname(buf, BUF_SIZE);
+  if (result != 0) {
+    return Error("Could not get local hostname");
+  }
+  return std::string(buf);
 }
 
 }  // namespace serenity

--- a/tests/serenity/os_utils_tests.cpp
+++ b/tests/serenity/os_utils_tests.cpp
@@ -2,11 +2,11 @@
 #include <string>
 
 #include "gtest/gtest.h"
-#include "mesos/mesos.hpp"
 
-#include "stout/result.hpp"
+#include "stout/try.hpp"
 
 #include "serenity/os_utils.hpp"
+
 
 namespace mesos {
 namespace serenity {
@@ -25,11 +25,18 @@ TEST(EnviromentVariableInitializer, GetEnvVariable) {
   ASSERT_EQ(res.get(), envVal);
 }
 
+
 TEST(EnviromentVariableInitializer, GetUnexistantEnvVariable) {
   const std::string envName = "SERENITY_TEST_ENV_VAR_NON_EXISTENT";
 
   Option<std::string> res = GetEnviromentVariable(envName.c_str());
   ASSERT_TRUE(res.isNone());
+}
+
+
+TEST(GetHostname, GetHostname) {
+  Try<std::string> hostname = GetHostname();
+  ASSERT_TRUE(hostname.isSome());
 }
 
 }  // namespace tests


### PR DESCRIPTION
Local mesos agent is now discovered by use of GetHostName