### PR TITLE
Fixed IPC to not include previous value in calculations.

### DIFF
--- a/filters/ema.cpp
+++ b/filters/ema.cpp
@@ -75,7 +75,7 @@ Try<Nothing> EMAFilter::consume(const ResourceUsage& in) {
     if (emaSample == this->emaSamples->end()) {
       SERENITY_LOG(ERROR) << "First EMA iteration for: "
                           << WID(inExec.executor_info()).toString();
-      // If not insert new one.
+      // If not - insert new one.
       ExponentialMovingAverage ema(EMA_REGULAR_SERIES, this->alpha);
       emaSamples->insert(std::pair<ExecutorInfo, ExponentialMovingAverage>(
           inExec.executor_info(), ema));

--- a/pipeline/qos_pipeline.hpp
+++ b/pipeline/qos_pipeline.hpp
@@ -34,10 +34,6 @@ using QoSControllerPipeline = Pipeline<ResourceUsage, QoSCorrections>;
  *       {{ Valve }} (+http endpoint) // First item.
  *            |
  *      |ResourceUsage|
- *            |
- * {{ Utilization Observer }}
- *            |
- *      |ResourceUsage|
  *       /          \
  *       |  {{ OnlyPRTaskFilter }}
  *       |           |
@@ -83,13 +79,9 @@ class CpuQoSPipeline : public QoSControllerPipeline {
           conf.emaAlpha,
           Tag(QOS_CONTROLLER, "emaFilter")),
       prExecutorPassFilter(&emaFilter),
-      utilizationFilter(
-          &prExecutorPassFilter,
-          conf.utilizationThreshold,
-          Tag(QOS_CONTROLLER, "utilizationFilter")),
       // First item in pipeline. For now, close the pipeline for QoS.
       valveFilter(
-          &utilizationFilter,
+          &prExecutorPassFilter,
           conf.valveOpened,
           Tag(QOS_CONTROLLER, "valveFilter")) {
     // Setup starting producer.
@@ -117,7 +109,6 @@ class CpuQoSPipeline : public QoSControllerPipeline {
   EMAFilter emaFilter;
   DropFilter<Detector> ipcDropFilter;
   PrExecutorPassFilter prExecutorPassFilter;
-  UtilizationThresholdFilter utilizationFilter;
   ValveFilter valveFilter;
 
   // --- Observers ---

--- a/qos_controller/serenity_controller.hpp
+++ b/qos_controller/serenity_controller.hpp
@@ -25,12 +25,16 @@ class SerenityControllerProcess;
 
 class SerenityController: public slave::QoSController {
  public:
-  explicit SerenityController(std::shared_ptr<QoSControllerPipeline> _pipeline)
-    : pipeline(_pipeline) {}
+  explicit SerenityController(
+      std::shared_ptr<QoSControllerPipeline> _pipeline,
+      double _onEmptyCorrectionInterval)
+    : pipeline(_pipeline),
+      onEmptyCorrectionInterval(_onEmptyCorrectionInterval) {}
 
   static Try<slave::QoSController*> create(
-      std::shared_ptr<QoSControllerPipeline> _pipeline) {
-    return new SerenityController(_pipeline);
+      std::shared_ptr<QoSControllerPipeline> _pipeline,
+      double _onEmptyCorrectionInterval = 5) {
+    return new SerenityController(_pipeline, _onEmptyCorrectionInterval);
   }
 
   virtual ~SerenityController();
@@ -43,6 +47,7 @@ class SerenityController: public slave::QoSController {
  protected:
   process::Owned<SerenityControllerProcess> process;
   std::shared_ptr<QoSControllerPipeline> pipeline;
+  double onEmptyCorrectionInterval;
 };
 
 }  // namespace serenity

--- a/serenity/config.hpp
+++ b/serenity/config.hpp
@@ -56,20 +56,16 @@ struct QoSPipelineConf {
   explicit QoSPipelineConf(
       ChangePointDetectionState _cpdState,
       double_t _emaAlpha,
-      double_t _utilizationThreshold,
       bool _visualisation,
       bool _valveOpened)
     : cpdState(_cpdState),
       emaAlpha(_emaAlpha),
-      utilizationThreshold(_utilizationThreshold),
       visualisation(_visualisation),
       valveOpened(_valveOpened) {}
 
   ChangePointDetectionState cpdState;
 
   double_t emaAlpha = ema::DEFAULT_ALPHA;
-
-  double_t utilizationThreshold = utilization::DEFAULT_THRESHOLD;
 
   bool visualisation = true;
 

--- a/serenity/data_utils.hpp
+++ b/serenity/data_utils.hpp
@@ -17,7 +17,7 @@ using GetterFunction = Try<double_t>(
 inline Try<double_t> getIpc(
     const ResourceUsage_Executor& previousExec,
     const ResourceUsage_Executor& currentExec) {
-  Try<double_t> ipc = CountIpc(previousExec, currentExec);
+  Try<double_t> ipc = CountIpc(currentExec);
   if (ipc.isError()) return Error(ipc.error());
 
   return ipc;

--- a/tests/common/load_generator.hpp
+++ b/tests/common/load_generator.hpp
@@ -209,16 +209,11 @@ inline ResourceUsage_Executor generateIPC(
   ResourceUsage_Executor executorUsage;
   executorUsage.CopyFrom(_executorUsage);
 
-  double_t previousInstructions =
-    executorUsage.statistics().perf().instructions();
-  double_t previousCycles =
-    executorUsage.statistics().perf().cycles();
+  executorUsage.mutable_statistics()
+      ->mutable_perf()->set_instructions(_IpcValue);
 
   executorUsage.mutable_statistics()
-      ->mutable_perf()->set_instructions(previousInstructions + _IpcValue);
-
-  executorUsage.mutable_statistics()
-      ->mutable_perf()->set_cycles(previousCycles + ACCURACY_MODIFIER);
+      ->mutable_perf()->set_cycles(ACCURACY_MODIFIER);
 
   executorUsage.mutable_statistics()
       ->mutable_perf()->set_timestamp(_timestamp);

--- a/tests/filters/ema_test.cpp
+++ b/tests/filters/ema_test.cpp
@@ -127,7 +127,7 @@ TEST(EMATest, SmoothingNoisySinStableDrop) {
       LOAD_ITERATIONS);
 
   for (; loadGen.end() ; loadGen++) {
-    // Introduce stable drop in the middle of the test..
+    // Introduce stable drop in the middle of the test.
     if (loadGen.iteration > 100 &&
         loadGen.iteration < 150) loadGen.modifier -= DROP_PROGRES;
 
@@ -233,7 +233,7 @@ TEST(EMATest, IpcEMATestNoisyConstSample) {
                     (*loadGen)(),
                     (*loadGen).timestamp));
 
-    // Run pipeline iteration
+    // Run pipeline iteration.
     source.produce(usage);
 
     if (loadGen.iteration > 0)

--- a/tests/fixtures/ema/test.json
+++ b/tests/fixtures/ema/test.json
@@ -1,1 +1,272 @@
-{"resource_usage":[{"executors":[{"allocated":[{"name":"cpus","role":"*","scalar":{"value":1.1},"type":"SCALAR"},{"name":"mem","role":"*","scalar":{"value":160},"type":"SCALAR"}],"executor_info":{"command":{"shell":true,"value":"/home/skonefal/usr/libexec/mesos/mesos-executor"},"executor_id":{"value":"serenity2"},"framework_id":{"value":"20150612-182512-16842879-5050-6428-0001"},"name":"Command Executor (Task: test1) (Command: sh -c 'watch pwd')","resources":[{"name":"cpus","role":"*","scalar":{"value":0.1},"type":"SCALAR"},{"name":"mem","role":"*","scalar":{"value":32},"type":"SCALAR"}],"source":"serenity2"},"statistics":{"cpus_limit":1.1,"cpus_system_time_secs":0.03,"cpus_user_time_secs":0.07,"mem_limit_bytes":167772160,"mem_rss_bytes":70057984,"perf":{"cycles":48717706,"instructions":13838911,"timestamp":1434126327.20772},"timestamp":1434126327.18446}},{"allocated":[{"name":"cpus","role":"*","scalar":{"value":1.1},"type":"SCALAR"},{"name":"mem","role":"*","scalar":{"value":160},"type":"SCALAR"}],"executor_info":{"command":{"shell":true,"value":"/home/skonefal/usr/libexec/mesos/mesos-executor"},"executor_id":{"value":"test1"},"framework_id":{"value":"20150612-182512-16842879-5050-6428-0000"},"name":"Command Executor (Task: test2) (Command: sh -c 'watch ls')","resources":[{"name":"cpus","role":"*","scalar":{"value":0.1},"type":"SCALAR"},{"name":"mem","role":"*","scalar":{"value":32},"type":"SCALAR"}],"source":"test1"},"statistics":{"cpus_limit":1.1,"cpus_system_time_secs":0.05,"cpus_user_time_secs":0.1,"mem_limit_bytes":167772160,"mem_rss_bytes":71229440,"perf":{"cycles":48717706,"instructions":13838911,"timestamp":1434126327.20772},"timestamp":1434126327.20772}}]},{"executors":[{"allocated":[{"name":"cpus","role":"*","scalar":{"value":1.1},"type":"SCALAR"},{"name":"mem","role":"*","scalar":{"value":160},"type":"SCALAR"}],"executor_info":{"command":{"shell":true,"value":"/home/skonefal/usr/libexec/mesos/mesos-executor"},"executor_id":{"value":"serenity2"},"framework_id":{"value":"20150612-182512-16842879-5050-6428-0001"},"name":"Command Executor (Task: serenity2) (Command: sh -c 'watch pwd')","resources":[{"name":"cpus","role":"*","scalar":{"value":0.1},"type":"SCALAR"},{"name":"mem","role":"*","scalar":{"value":32},"type":"SCALAR"}],"source":"serenity2"},"statistics":{"cpus_limit":1.1,"cpus_system_time_secs":0.08,"cpus_user_time_secs":0.12,"mem_limit_bytes":167772160,"mem_rss_bytes":70057984,"perf":{"cycles":48717726,"instructions":13838921,"timestamp":1434126328.20772},"timestamp":1434126328.18446}},{"allocated":[{"name":"cpus","role":"*","scalar":{"value":1.1},"type":"SCALAR"},{"name":"mem","role":"*","scalar":{"value":160},"type":"SCALAR"}],"executor_info":{"command":{"shell":true,"value":"/home/skonefal/usr/libexec/mesos/mesos-executor"},"executor_id":{"value":"test1"},"framework_id":{"value":"20150612-182512-16842879-5050-6428-0000"},"name":"Command Executor (Task: test1) (Command: sh -c 'watch ls')","resources":[{"name":"cpus","role":"*","scalar":{"value":0.1},"type":"SCALAR"},{"name":"mem","role":"*","scalar":{"value":32},"type":"SCALAR"}],"source":"test1"},"statistics":{"cpus_limit":1.1,"cpus_system_time_secs":0.05,"cpus_user_time_secs":0.1,"mem_limit_bytes":167772160,"mem_rss_bytes":71229440,"perf":{"cycles":48717716,"instructions":13838931,"timestamp":1434126328.20772},"timestamp":1434126328.20772}}]}]}
+{
+  "resource_usage": [
+    {
+      "executors": [
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 1.1
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/skonefal/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenity2"
+            },
+            "framework_id": {
+              "value": "20150612-182512-16842879-5050-6428-0001"
+            },
+            "name": "Command Executor (Task: test1) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenity2"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 0.03,
+            "cpus_user_time_secs": 0.07,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70057984,
+            "perf": {
+              "cycles": 48717706,
+              "instructions": 13838911,
+              "timestamp": 1434126327.20772
+            },
+            "timestamp": 1434126327.18446
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 1.1
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/skonefal/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "test1"
+            },
+            "framework_id": {
+              "value": "20150612-182512-16842879-5050-6428-0000"
+            },
+            "name": "Command Executor (Task: test2) (Command: sh -c 'watch ls')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "test1"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 0.05,
+            "cpus_user_time_secs": 0.1,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 71229440,
+            "perf": {
+              "cycles": 48717706,
+              "instructions": 13838911,
+              "timestamp": 1434126327.20772
+            },
+            "timestamp": 1434126327.20772
+          }
+        }
+      ]
+    },
+    {
+      "executors": [
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 1.1
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/skonefal/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenity2"
+            },
+            "framework_id": {
+              "value": "20150612-182512-16842879-5050-6428-0001"
+            },
+            "name": "Command Executor (Task: serenity2) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenity2"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 0.08,
+            "cpus_user_time_secs": 0.12,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70057984,
+            "perf": {
+              "cycles": 20,
+              "instructions": 10,
+              "timestamp": 1434126328.20772
+            },
+            "timestamp": 1434126328.18446
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 1.1
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/skonefal/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "test1"
+            },
+            "framework_id": {
+              "value": "20150612-182512-16842879-5050-6428-0000"
+            },
+            "name": "Command Executor (Task: test1) (Command: sh -c 'watch ls')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "test1"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 0.05,
+            "cpus_user_time_secs": 0.1,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 71229440,
+            "perf": {
+              "cycles": 10,
+              "instructions": 20,
+              "timestamp": 1434126328.20772
+            },
+            "timestamp": 1434126328.20772
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/pipeline/qos_pipeline_test.cpp
+++ b/tests/pipeline/qos_pipeline_test.cpp
@@ -45,7 +45,6 @@ TEST(QoSPipelineTest, FiltersNotProperlyFed) {
                   CONTENTION_COOLDOWN,
                   RELATIVE_THRESHOLD),
               ema::DEFAULT_ALPHA,
-              utilization::DEFAULT_THRESHOLD,
               false,
               true));
 
@@ -87,7 +86,6 @@ TEST(QoSPipelineTest, NoCorrections) {
                   CONTENTION_COOLDOWN,
                   RELATIVE_THRESHOLD),
               ema::DEFAULT_ALPHA,
-              utilization::DEFAULT_THRESHOLD,
               false,
               true));
 
@@ -133,7 +131,6 @@ TEST(QoSPipelineTest, RollingDetectorOneDropCorrectionsNoEma) {
                   CONTENTION_COOLDOWN,
                   RELATIVE_THRESHOLD),
               1,  // Alpha = 1 means no smoothing.
-              utilization::DEFAULT_THRESHOLD,
               false,
               true));
 
@@ -201,7 +198,6 @@ TEST(QoSPipelineTest, RollingDetectorOneDropCorrectionsWithEma) {
                   CONTENTION_COOLDOWN,
                   RELATIVE_THRESHOLD),
               0.2,  // Alpha = 1 means no smoothing. 0.2 means high smoothing.
-              utilization::DEFAULT_THRESHOLD,
               false,
               true));
 


### PR DESCRIPTION
- added IPS calculation function.
- QpS configuration variables  are in one place for ease of use.
- removed utilization threshold filter from QoS pipeline (we don't need that in Qos flow)
- added customizable variable for qos interval.

TODO: Force ema filter not to remember previous usage if not needed.

Signed-off-by: bplotka <bwplotka@gmail.com>