### PR TITLE
IPC drop detection improvement

### DIFF
--- a/filters/drop.hpp
+++ b/filters/drop.hpp
@@ -95,13 +95,14 @@ class RollingChangePointDetector : public ChangePointDetector {
  * Algorithm steps:
  * - Warm up phase: wait "windowsSize" iterations.
  * - fetch base point value from (currentIteration - "windowsSize").
- * - Check if new value drops below the (relativeFractionThreshold*base point).
+ * - Check if new value drops more than fraction of basePoint specified
+ *   in fractionalThreshold option.
  *
  *  We can use EMA value as input for better results.
  */
-class RollingFractionalChangePointDetector : public ChangePointDetector {
+class RollingFractionalDetector : public ChangePointDetector {
  public:
-  RollingFractionalChangePointDetector() {}
+  RollingFractionalDetector() {}
 
   virtual Result<ChangePointDetection> processSample(double_t in);
 

--- a/filters/drop.hpp
+++ b/filters/drop.hpp
@@ -37,7 +37,7 @@ struct ChangePointDetection {
  */
 class ChangePointDetector {
  public:
-  ChangePointDetector() {}
+  ChangePointDetector(const Tag& _tag): tag(_tag) {}
 
   virtual Try<Nothing> configure(ChangePointDetectionState cpdState) {
     this->state = cpdState;
@@ -48,6 +48,7 @@ class ChangePointDetector {
   virtual Result<ChangePointDetection> processSample(double_t in) = 0;
 
  protected:
+  const Tag tag;
   ChangePointDetectionState state;
   uint64_t contentionCooldownCounter = 0;
 };
@@ -64,7 +65,7 @@ class ChangePointDetector {
  */
 class NaiveChangePointDetector : public ChangePointDetector {
  public:
-  NaiveChangePointDetector() {}
+  NaiveChangePointDetector(const Tag& _tag): ChangePointDetector(_tag) {}
 
   virtual Result<ChangePointDetection> processSample(double_t in);
 };
@@ -81,7 +82,7 @@ class NaiveChangePointDetector : public ChangePointDetector {
  */
 class RollingChangePointDetector : public ChangePointDetector {
  public:
-  RollingChangePointDetector() {}
+  RollingChangePointDetector(const Tag& _tag): ChangePointDetector(_tag) {}
 
   virtual Result<ChangePointDetection> processSample(double_t in);
 
@@ -102,7 +103,7 @@ class RollingChangePointDetector : public ChangePointDetector {
  */
 class RollingFractionalDetector : public ChangePointDetector {
  public:
-  RollingFractionalDetector() {}
+  RollingFractionalDetector(const Tag& _tag): ChangePointDetector(_tag) {}
 
   virtual Result<ChangePointDetection> processSample(double_t in);
 

--- a/filters/drop.hpp
+++ b/filters/drop.hpp
@@ -77,11 +77,31 @@ class NaiveChangePointDetector : public ChangePointDetector {
  * - fetch base point value from (currentIteration - "windowsSize").
  * - Check if new value drops below the (base point - relativeThreshold).
  *
- *  We should use EMA value as input for better results.
+ *  We can use EMA value as input for better results.
  */
 class RollingChangePointDetector : public ChangePointDetector {
  public:
   RollingChangePointDetector() {}
+
+  virtual Result<ChangePointDetection> processSample(double_t in);
+
+ protected:
+  std::list<double_t> window;
+};
+
+
+/**
+ * Dynamic implementation of sequential change point detection.
+ * Algorithm steps:
+ * - Warm up phase: wait "windowsSize" iterations.
+ * - fetch base point value from (currentIteration - "windowsSize").
+ * - Check if new value drops below the (relativeFractionThreshold*base point).
+ *
+ *  We can use EMA value as input for better results.
+ */
+class RollingFractionalChangePointDetector : public ChangePointDetector {
+ public:
+  RollingFractionalChangePointDetector() {}
 
   virtual Result<ChangePointDetection> processSample(double_t in);
 

--- a/filters/drop.hpp
+++ b/filters/drop.hpp
@@ -37,7 +37,7 @@ struct ChangePointDetection {
  */
 class ChangePointDetector {
  public:
-  ChangePointDetector(const Tag& _tag): tag(_tag) {}
+  explicit ChangePointDetector(const Tag& _tag): tag(_tag) {}
 
   virtual Try<Nothing> configure(ChangePointDetectionState cpdState) {
     this->state = cpdState;
@@ -65,7 +65,8 @@ class ChangePointDetector {
  */
 class NaiveChangePointDetector : public ChangePointDetector {
  public:
-  NaiveChangePointDetector(const Tag& _tag): ChangePointDetector(_tag) {}
+  explicit NaiveChangePointDetector(const Tag& _tag)
+    : ChangePointDetector(_tag) {}
 
   virtual Result<ChangePointDetection> processSample(double_t in);
 };
@@ -82,7 +83,8 @@ class NaiveChangePointDetector : public ChangePointDetector {
  */
 class RollingChangePointDetector : public ChangePointDetector {
  public:
-  RollingChangePointDetector(const Tag& _tag): ChangePointDetector(_tag) {}
+  explicit RollingChangePointDetector(const Tag& _tag)
+    : ChangePointDetector(_tag) {}
 
   virtual Result<ChangePointDetection> processSample(double_t in);
 
@@ -103,7 +105,8 @@ class RollingChangePointDetector : public ChangePointDetector {
  */
 class RollingFractionalDetector : public ChangePointDetector {
  public:
-  RollingFractionalDetector(const Tag& _tag): ChangePointDetector(_tag) {}
+  explicit RollingFractionalDetector(const Tag& _tag)
+    : ChangePointDetector(_tag) {}
 
   virtual Result<ChangePointDetection> processSample(double_t in);
 

--- a/observers/qos_correction.cpp
+++ b/observers/qos_correction.cpp
@@ -115,8 +115,9 @@ Try<QoSCorrections> SeverityBasedCpuDecider::decide(
 
       if (severity > 0) {
         // In such case even if we kill all BE executors contention is not
-        // solved.
-        LOG(ERROR) << QoSCorrectionObserver::name <<
+        // solved. That could mean we badly estimated severity or
+        // aggressors are not the cause of CPU contention.
+        LOG(INFO) << QoSCorrectionObserver::name <<
                       "Aggressors are not the cause of CPU contention"
                       " or lack of info about some aggressors.";
         break;

--- a/pipeline/qos_pipeline.hpp
+++ b/pipeline/qos_pipeline.hpp
@@ -119,6 +119,102 @@ class CpuQoSPipeline : public QoSControllerPipeline {
   ResourceUsageTimeSeriesExporter emaFilteredResourcesExporter;
 };
 
+
+/**
+ * Pipeline which includes necessary filters for making  QoS Corrections
+ * based on CPU contentions. (IPS signal)
+ *   {{ PIPELINE SOURCE }}
+ *            |           \
+ *      |ResourceUsage|  |ResourceUsage| - {{ Raw Resource Usage Export }}
+ *            |
+ *       {{ Valve }} (+http endpoint) // First item.
+ *            |
+ *      |ResourceUsage|
+ *       /          \
+ *       |  {{ OnlyPRTaskFilter }}
+ *       |           |
+ *       |     |ResourceUsage|
+ *       |           |
+ *       |    {{ IPS EMA Filter }}
+ *       |           |          \
+ *       |     |ResourceUsage|  |ResourceUsage| - {{EMA Resource Usage Export}}
+ *       |           |
+ *       |     {{ IPS Drop<ChangePointDetector> }}
+ *       |           |
+ *       |      |Contentions|
+ *       |           |
+ * {{ QoS Correction Observer }} // Last item.
+ *            |
+ *      |Corrections|
+ *            |
+ *    {{ PIPELINE SINK }}
+ *
+ * For detailed schema please see: docs/pipeline.md
+ */
+template<class Detector>
+class IpsQoSPipeline : public QoSControllerPipeline {
+  static_assert(std::is_base_of<ChangePointDetector, Detector>::value,
+                "Detector must derive from ChangePointDetector");
+
+ public:
+  explicit IpsQoSPipeline(QoSPipelineConf _conf)
+      : conf(_conf),
+      // Time series exporters.
+        rawResourcesExporter("raw"),
+        emaFilteredResourcesExporter("ema"),
+      // Last item in pipeline.
+        qoSCorrectionObserver(this, 1),
+        ipsDropFilter(
+            &qoSCorrectionObserver,
+            usage::getEmaIps,
+            conf.cpdState),
+        emaFilter(
+            &ipsDropFilter,
+            usage::getIps,
+            usage::setEmaIps,
+            conf.emaAlpha,
+            Tag(QOS_CONTROLLER, "emaFilter")),
+        prExecutorPassFilter(&emaFilter),
+      // First item in pipeline. For now, close the pipeline for QoS.
+        valveFilter(
+            &prExecutorPassFilter,
+            conf.valveOpened,
+            Tag(QOS_CONTROLLER, "valveFilter")) {
+    // Setup starting producer.
+    this->addConsumer(&valveFilter);
+
+    // QoSCorrection needs ResourceUsage as well.
+    valveFilter.addConsumer(&qoSCorrectionObserver);
+
+    // Setup Time Series export
+    if (conf.visualisation) {
+      this->addConsumer(&rawResourcesExporter);
+      emaFilter.addConsumer(&emaFilteredResourcesExporter);
+    }
+  }
+
+  virtual Try<Nothing> resetSyncConsumers() {
+    this->qoSCorrectionObserver.reset();
+
+    return Nothing();
+  }
+
+ private:
+  QoSPipelineConf conf;
+  // --- Filters ---
+  EMAFilter emaFilter;
+  DropFilter<Detector> ipsDropFilter;
+  PrExecutorPassFilter prExecutorPassFilter;
+  ValveFilter valveFilter;
+
+  // --- Observers ---
+  QoSCorrectionObserver qoSCorrectionObserver;
+
+  // --- Time Series Exporters ---
+  ResourceUsageTimeSeriesExporter rawResourcesExporter;
+  ResourceUsageTimeSeriesExporter emaFilteredResourcesExporter;
+};
+
 }  // namespace serenity
 }  // namespace mesos
 

--- a/pipeline/qos_pipeline.hpp
+++ b/pipeline/qos_pipeline.hpp
@@ -71,7 +71,8 @@ class CpuQoSPipeline : public QoSControllerPipeline {
       ipcDropFilter(
           &qoSCorrectionObserver,
           usage::getEmaIpc,
-          conf.cpdState),
+          conf.cpdState,
+          Tag(QOS_CONTROLLER, "IPC dropFilter")),
       emaFilter(
           &ipcDropFilter,
           usage::getIpc,
@@ -167,7 +168,8 @@ class IpsQoSPipeline : public QoSControllerPipeline {
         ipsDropFilter(
             &qoSCorrectionObserver,
             usage::getEmaIps,
-            conf.cpdState),
+            conf.cpdState,
+            Tag(QOS_CONTROLLER, "IPS dropFilter")),
         emaFilter(
             &ipsDropFilter,
             usage::getIps,

--- a/qos_controller/serenity_controller_module.cpp
+++ b/qos_controller/serenity_controller_module.cpp
@@ -21,6 +21,7 @@
 using namespace mesos;  // NOLINT(build/namespaces)
 
 using mesos::serenity::ChangePointDetectionState;
+using mesos::serenity::CpuQoSPipeline;
 using mesos::serenity::IpsQoSPipeline;
 using mesos::serenity::RollingFractionalDetector;
 using mesos::serenity::SerenityController;
@@ -29,7 +30,57 @@ using mesos::serenity::QoSPipelineConf;
 
 using mesos::slave::QoSController;
 
-static QoSController* createSerenityController(const Parameters& parameters) {
+static QoSController* createIpcSerenityController(
+    const Parameters& parameters) {
+  LOG(INFO) << "Loading Serenity QoS Controller module";
+  // TODO(bplotka): Fetch configuration from parameters or conf file
+  // to customize IpsDrop
+
+  // --Hardcoded configuration for Serenity QoS Controller---
+
+  QoSPipelineConf conf;
+  ChangePointDetectionState cpdState;
+  // Detector configuration:
+  // How far we look back in samples.
+  cpdState.windowSize = 10;
+  // How many iterations detector will wait with creating another
+  // contention.
+  cpdState.contentionCooldown = 10;
+  // Defines how much (relatively to base point) value must drop to trigger
+  // contention.
+  // Most detectors will use that.
+  cpdState.fractionalThreshold = 0.5;
+  // Defines how to convert difference in values to CPU.
+  // This option helps RollingFractionalDetector to estimate severity of
+  // drop.
+  cpdState.differenceToCPU = 0.4;  // 0.4 IPC drop means ~ 1 CPU to kill.
+
+  conf.cpdState = cpdState;
+  conf.emaAlpha = 0.8;
+  conf.visualisation = true;
+  // Let's start with QoS pipeline disabled.
+  conf.valveOpened = false;
+
+  // Since slave is configured for 5 second perf interval, it is useless to
+  // check correction more often then 5 sec.
+  double onEmptyCorrectionInterval = 5;
+
+  // --End of hardcoded configuration for Serenity QoS Controller---
+
+  Try<QoSController*> result =
+      SerenityController::create(
+          std::shared_ptr<QoSControllerPipeline>(
+              new CpuQoSPipeline<RollingFractionalDetector>(conf)),
+          onEmptyCorrectionInterval);
+
+  if (result.isError()) {
+    return NULL;
+  }
+  return result.get();
+}
+
+static QoSController* createIpsSerenityController(
+    const Parameters& parameters) {
   LOG(INFO) << "Loading Serenity QoS Controller module";
   // TODO(bplotka): Fetch configuration from parameters or conf file
   // to customize IpsDrop
@@ -85,4 +136,4 @@ mesos::modules::Module<QoSController> com_mesosphere_mesos_SerenityController(
     "support@mesosphere.com",
     "Serenity QoS Controller",
     NULL,
-    createSerenityController);
+    createIpcSerenityController);

--- a/qos_controller/serenity_controller_module.cpp
+++ b/qos_controller/serenity_controller_module.cpp
@@ -54,7 +54,7 @@ static QoSController* createSerenityController(const Parameters& parameters) {
   cpdState.differenceToCPU = 1000000000;  // 1 Billion.
 
   conf.cpdState = cpdState;
-  conf.emaAlpha = 0.3;
+  conf.emaAlpha = 0.8;
   conf.visualisation = true;
   // Let's start with QoS pipeline disabled.
   conf.valveOpened = false;

--- a/qos_controller/serenity_controller_module.cpp
+++ b/qos_controller/serenity_controller_module.cpp
@@ -51,7 +51,7 @@ static QoSController* createSerenityController(const Parameters& parameters) {
   // Defines how many instructions can be done per one CPU in one second.
   // This option helps RollingFractionalDetector to estimate severity of
   // drop.
-  cpdState.instructionPerCpu = 1000000000;  // 1 Billion.
+  cpdState.differenceToCPU = 1000000000;  // 1 Billion.
 
   conf.cpdState = cpdState;
   conf.emaAlpha = 0.3;

--- a/serenity/config.hpp
+++ b/serenity/config.hpp
@@ -54,11 +54,10 @@ struct ChangePointDetectionState {
   double_t fractionalThreshold =
     changepoint::DEFAULT_FRACTIONAL_THRESHOLD;
 
-  //! Defines how many instructions can be done per one CPU in one second.
+  //! Defines how to convert difference in values to CPU.
   //! This option helps RollingFractionalDetector to estimate severity of
   //! drop.
-  double_t instructionPerCpu =
-      changepoint::DEFAULT_INSTRUCTIONS_PER_CPU;
+  double_t differenceToCPU = changepoint::DEFAULT_DIFFERENCE_TO_CPU;
 };
 
 

--- a/serenity/config.hpp
+++ b/serenity/config.hpp
@@ -47,6 +47,12 @@ struct ChangePointDetectionState {
   //! Defines how much value must drop to trigger contention.
   //! Most detectors will use that.
   double_t relativeThreshold = changepoint::DEFAULT_RELATIVE_THRESHOLD;
+
+  //! Defines how much (relatively to base point) value must drop to trigger
+  //! contention.
+  //! Most detectors will use that.
+  double_t fractionalThreshold =
+    changepoint::DEFAULT_FRACTIONAL_THRESHOLD;
 };
 
 

--- a/serenity/config.hpp
+++ b/serenity/config.hpp
@@ -53,6 +53,12 @@ struct ChangePointDetectionState {
   //! Most detectors will use that.
   double_t fractionalThreshold =
     changepoint::DEFAULT_FRACTIONAL_THRESHOLD;
+
+  //! Defines how many instructions can be done per one CPU in one second.
+  //! This option helps RollingFractionalDetector to estimate severity of
+  //! drop.
+  double_t instructionPerCpu =
+      changepoint::DEFAULT_INSTRUCTIONS_PER_CPU;
 };
 
 

--- a/serenity/data_utils.hpp
+++ b/serenity/data_utils.hpp
@@ -38,6 +38,30 @@ inline Try<double_t> getEmaIpc(
 }
 
 
+inline Try<double_t> getIps(
+    const ResourceUsage_Executor& previousExec,
+    const ResourceUsage_Executor& currentExec) {
+  Try<double_t> ips = CountIps(currentExec);
+  if (ips.isError()) return Error(ips.error());
+
+  return ips;
+}
+
+// TODO(bplotka): Move it to other double field.
+/**
+ * Currently we are saving EMA IPS in net_tcp_active_connections field
+ * in ResourceUsage.
+ */
+inline Try<double_t> getEmaIps(
+    const ResourceUsage_Executor& previousExec,
+    const ResourceUsage_Executor& currentExec) {
+  if (!currentExec.statistics().has_net_tcp_active_connections())
+    return Error("Ema IPS is not filled");
+
+  return currentExec.statistics().net_tcp_active_connections();
+}
+
+
 inline Try<double_t> getCpuUsage(
     const ResourceUsage_Executor& previousExec,
     const ResourceUsage_Executor& currentExec) {
@@ -74,6 +98,20 @@ using SetterFunction = Try<Nothing>(
  * in ResourceUsage.
  */
 inline Try<Nothing> setEmaIpc(
+    const double_t value,
+    ResourceUsage_Executor* outExec) {
+
+  outExec->mutable_statistics()->set_net_tcp_active_connections(value);
+
+  return Nothing();
+}
+
+// TODO(bplotka): Move it to other double field.
+/**
+ * Currently we are saving EMA IPS in net_tcp_active_connections field
+ * in ResourceUsage.
+ */
+inline Try<Nothing> setEmaIps(
     const double_t value,
     ResourceUsage_Executor* outExec) {
 

--- a/serenity/default_vars.hpp
+++ b/serenity/default_vars.hpp
@@ -22,6 +22,7 @@ constexpr uint64_t DEFAULT_WINDOW_SIZE = 10;
 constexpr uint64_t DEFAULT_CONTENTION_COOLDOWN = 10;
 constexpr double DEFAULT_ABS_THRESHOLD = 0;
 constexpr double DEFAULT_RELATIVE_THRESHOLD = 20;
+constexpr double DEFAULT_FRACTIONAL_THRESHOLD = 0.5;
 
 }  // namespace changepoint
 

--- a/serenity/default_vars.hpp
+++ b/serenity/default_vars.hpp
@@ -23,6 +23,7 @@ constexpr uint64_t DEFAULT_CONTENTION_COOLDOWN = 10;
 constexpr double DEFAULT_ABS_THRESHOLD = 0;
 constexpr double DEFAULT_RELATIVE_THRESHOLD = 20;
 constexpr double DEFAULT_FRACTIONAL_THRESHOLD = 0.5;
+constexpr double DEFAULT_INSTRUCTIONS_PER_CPU = 1000000000;
 
 }  // namespace changepoint
 

--- a/serenity/default_vars.hpp
+++ b/serenity/default_vars.hpp
@@ -23,7 +23,7 @@ constexpr uint64_t DEFAULT_CONTENTION_COOLDOWN = 10;
 constexpr double DEFAULT_ABS_THRESHOLD = 0;
 constexpr double DEFAULT_RELATIVE_THRESHOLD = 20;
 constexpr double DEFAULT_FRACTIONAL_THRESHOLD = 0.5;
-constexpr double DEFAULT_INSTRUCTIONS_PER_CPU = 1000000000;
+constexpr double DEFAULT_DIFFERENCE_TO_CPU = 1000000000;
 
 }  // namespace changepoint
 

--- a/serenity/metrics_helper.hpp
+++ b/serenity/metrics_helper.hpp
@@ -102,7 +102,7 @@ inline Try<double_t> CountIps(const ResourceUsage_Executor& current) {
                      "statistics");
   if (!current.statistics().has_perf() ||
       !current.statistics().perf().has_timestamp() ||
-      !current.statistics().perf().has_cycles() ||
+      !current.statistics().perf().has_duration() ||
       !current.statistics().perf().has_instructions()) {
     return Error("Cannot count IPS, Parameter does not have required "
                      "perf statistics");

--- a/serenity/serenity.hpp
+++ b/serenity/serenity.hpp
@@ -119,7 +119,7 @@ enum ModuleType {
 #define SERENITY_LOG(severity) LOG(severity) << this->tag.NAME()
 
 class Tag {
-public:
+ public:
   Tag(const ModuleType& _type, const std::string& _name)
       : type(_type), name(_name) {
     this->fullName = this->init();
@@ -156,7 +156,7 @@ public:
     return aim;
   }
 
-protected:
+ protected:
   const std::string name;
   const ModuleType type;
   std::string fullName;

--- a/serenity/serenity.hpp
+++ b/serenity/serenity.hpp
@@ -116,10 +116,12 @@ enum ModuleType {
 };
 
 
+#define SERENITY_LOG(severity) LOG(severity) << this->tag.NAME()
+
 class Tag {
- public:
+public:
   Tag(const ModuleType& _type, const std::string& _name)
-    : type(_type), name(_name) {
+      : type(_type), name(_name) {
     this->fullName = this->init();
   }
 
@@ -154,15 +156,13 @@ class Tag {
     return aim;
   }
 
- protected:
+protected:
   const std::string name;
   const ModuleType type;
   std::string fullName;
   std::string prefix;
   std::string aim;
 };
-
-#define SERENITY_LOG(severity) LOG(severity) << this->tag.NAME()
 
 }  // namespace serenity
 }  // namespace mesos

--- a/tests/common/load_generator.hpp
+++ b/tests/common/load_generator.hpp
@@ -221,6 +221,33 @@ inline ResourceUsage_Executor generateIPC(
   return executorUsage;
 }
 
+
+/**
+* This function fills instructions perf events to match given
+* IPC value.
+*/
+inline ResourceUsage_Executor generateIPS(
+    const ResourceUsage_Executor _executorUsage,
+    double_t _IpsValue,
+    double_t _timestamp) {
+  const int ACCURACY_MODIFIER = 10;
+  // This function generates IPS with 1/ACCURACY_MODIFIER accuracy.
+  _IpsValue *= ACCURACY_MODIFIER;
+  ResourceUsage_Executor executorUsage;
+  executorUsage.CopyFrom(_executorUsage);
+
+  executorUsage.mutable_statistics()
+      ->mutable_perf()->set_instructions(_IpsValue);
+
+  executorUsage.mutable_statistics()
+      ->mutable_perf()->set_duration(ACCURACY_MODIFIER);
+
+  executorUsage.mutable_statistics()
+      ->mutable_perf()->set_timestamp(_timestamp);
+
+  return executorUsage;
+}
+
 }  // namespace tests
 }  // namespace serenity
 }  // namespace mesos

--- a/tests/filters/drop/naive_changepoint_test.cpp
+++ b/tests/filters/drop/naive_changepoint_test.cpp
@@ -25,7 +25,8 @@ TEST(NaiveChangePointDetectionTest, StableLoadNoChangePoint) {
   const uint64_t CONTENTION_COOLDOWN = 10;
   const double_t ABS_THRESHOLD = 0;
   const uint64_t LOAD_ITERATIONS = 100;
-  NaiveChangePointDetector naiveChangePointDetector;
+  NaiveChangePointDetector naiveChangePointDetector(
+      Tag(QOS_CONTROLLER, "Naive Detector"));
   naiveChangePointDetector.configure(
       ChangePointDetectionState::createForNaiveDetector(
           CONTENTION_COOLDOWN, ABS_THRESHOLD));
@@ -51,7 +52,8 @@ TEST(NaiveChangePointDetectionTest, NoisyLoadNoChangePoint) {
   const double_t ABS_THRESHOLD = 0;
   const double_t MAX_NOISE = 9;
   const uint64_t LOAD_ITERATIONS = 100;
-  NaiveChangePointDetector naiveChangePointDetector;
+  NaiveChangePointDetector naiveChangePointDetector(
+      Tag(QOS_CONTROLLER, "Naive Detector"));
   naiveChangePointDetector.configure(
       ChangePointDetectionState::createForNaiveDetector(
           CONTENTION_COOLDOWN, ABS_THRESHOLD));
@@ -79,7 +81,8 @@ TEST(NaiveChangePointDetectionTest, StableLoadOneChangePoint) {
   const double_t ABS_THRESHOLD = 0;
   const uint64_t LOAD_ITERATIONS = 200;
   const double_t DROP_PROGRES = 1;
-  NaiveChangePointDetector naiveChangePointDetector;
+  NaiveChangePointDetector naiveChangePointDetector(
+      Tag(QOS_CONTROLLER, "Naive Detector"));
   naiveChangePointDetector.configure(
       ChangePointDetectionState::createForNaiveDetector(
           CONTENTION_COOLDOWN, ABS_THRESHOLD));

--- a/tests/filters/drop/rolling_changepoint_test.cpp
+++ b/tests/filters/drop/rolling_changepoint_test.cpp
@@ -26,7 +26,8 @@ TEST(RollingChangePointDetectionTest, StableLoadNoChangePoint) {
   const uint64_t CONTENTION_COOLDOWN = 10;
   const double_t RELATIVE_THRESHOLD = 10;
   const uint64_t LOAD_ITERATIONS = 100;
-  RollingChangePointDetector rollingChangePointDetector;
+  RollingChangePointDetector rollingChangePointDetector(
+      Tag(QOS_CONTROLLER, "Rolling Detector"));
   rollingChangePointDetector.configure(
       ChangePointDetectionState::createForRollingDetector(
           WINDOWS_SIZE, CONTENTION_COOLDOWN, RELATIVE_THRESHOLD));
@@ -52,7 +53,8 @@ TEST(RollingChangePointDetectionTest, StableLoadOneChangePoint) {
   const double_t RELATIVE_THRESHOLD = 10;
   const double_t DROP_PROGRES = 2;
   const uint64_t LOAD_ITERATIONS = 200;
-  RollingChangePointDetector rollingChangePointDetector;
+  RollingChangePointDetector rollingChangePointDetector(
+      Tag(QOS_CONTROLLER, "Rolling Detector"));
   rollingChangePointDetector.configure(
       ChangePointDetectionState::createForRollingDetector(
           WINDOWS_SIZE, CONTENTION_COOLDOWN, RELATIVE_THRESHOLD));

--- a/tests/fixtures/pipeline/ips_qos_one_drop_correction.json
+++ b/tests/fixtures/pipeline/ips_qos_one_drop_correction.json
@@ -1,0 +1,1009 @@
+{
+  "resource_usage": [
+    {
+      "total": [
+        {
+          "name": "cpus",
+          "role": "*",
+          "scalar": {
+            "value": 24
+          },
+          "type": "SCALAR"
+        },
+        {
+          "name": "mem",
+          "role": "*",
+          "scalar": {
+            "value": 1024
+          },
+          "type": "SCALAR"
+        }
+      ],
+      "executors": [
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "revocable": {},
+              "role": "*",
+              "scalar": {
+                "value": 1
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityBe2"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityBe2) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityBe2"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "revocable": {},
+              "role": "*",
+              "scalar": {
+                "value": 0.5
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityBe1"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0001"
+            },
+            "name": "Command Executor (Task: serenityBe1) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityBe1"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "revocable": {},
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 0.5
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityBe0"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityBe0) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityBe0"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 4
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityPR"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityPR) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityPR"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "perf": {
+              "duration": 1,
+              "instructions": 3000000000,
+              "timestamp": 1434982907.7405
+            },
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 2
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityPR2"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityPR2) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityPR2"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "perf": {
+              "duration": 1,
+              "instructions": 4000000000,
+              "timestamp": 1434982907.7405
+            },
+            "timestamp": 1434982907.7405
+          }
+        }
+      ]
+    },
+    {
+      "total": [
+        {
+          "name": "cpus",
+          "role": "*",
+          "scalar": {
+            "value": 24
+          },
+          "type": "SCALAR"
+        },
+        {
+          "name": "mem",
+          "role": "*",
+          "scalar": {
+            "value": 1024
+          },
+          "type": "SCALAR"
+        }
+      ],
+      "executors": [
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "revocable": {},
+              "role": "*",
+              "scalar": {
+                "value": 1
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityBe2"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityBe2) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityBe2"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "revocable": {},
+              "role": "*",
+              "scalar": {
+                "value": 0.5
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityBe1"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0001"
+            },
+            "name": "Command Executor (Task: serenityBe1) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityBe1"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "revocable": {},
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 0.5
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityBe0"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityBe0) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityBe0"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 4
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityPR"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityPR) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityPR"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "perf": {
+              "duration": 1,
+              "instructions": 3000000000,
+              "timestamp": 1434982912.7405
+            },
+            "timestamp": 1434982912.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 2
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityPR2"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityPR2) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityPR2"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "perf": {
+              "duration": 1,
+              "instructions": 4000000000,
+              "timestamp": 1434982912.7405
+            },
+            "timestamp": 1434982912.7405
+          }
+        }
+      ]
+    },
+    {
+      "total": [
+        {
+          "name": "cpus",
+          "role": "*",
+          "scalar": {
+            "value": 24
+          },
+          "type": "SCALAR"
+        },
+        {
+          "name": "mem",
+          "role": "*",
+          "scalar": {
+            "value": 1024
+          },
+          "type": "SCALAR"
+        }
+      ],
+      "executors": [
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "revocable": {},
+              "role": "*",
+              "scalar": {
+                "value": 1
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityBe2"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityBe2) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityBe2"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "revocable": {},
+              "role": "*",
+              "scalar": {
+                "value": 0.5
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityBe1"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0001"
+            },
+            "name": "Command Executor (Task: serenityBe1) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityBe1"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "revocable": {},
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 0.5
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityBe0"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityBe0) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityBe0"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "timestamp": 1434982907.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 4
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityPR"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityPR) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityPR"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "perf": {
+              "duration": 1,
+              "instructions": 1000000000,
+              "timestamp": 1434982917.7405
+            },
+            "timestamp": 1434982917.7405
+          }
+        },
+        {
+          "allocated": [
+            {
+              "name": "cpus",
+              "role": "*",
+              "scalar": {
+                "value": 2
+              },
+              "type": "SCALAR"
+            },
+            {
+              "name": "mem",
+              "role": "*",
+              "scalar": {
+                "value": 160
+              },
+              "type": "SCALAR"
+            }
+          ],
+          "executor_info": {
+            "command": {
+              "shell": true,
+              "value": "/home/mesos/usr/libexec/mesos/mesos-executor"
+            },
+            "executor_id": {
+              "value": "serenityPR2"
+            },
+            "framework_id": {
+              "value": "20150622-161150-16842879-5050-16372-0000"
+            },
+            "name": "Command Executor (Task: serenityPR2) (Command: sh -c 'watch pwd')",
+            "resources": [
+              {
+                "name": "cpus",
+                "role": "*",
+                "scalar": {
+                  "value": 0.1
+                },
+                "type": "SCALAR"
+              },
+              {
+                "name": "mem",
+                "role": "*",
+                "scalar": {
+                  "value": 32
+                },
+                "type": "SCALAR"
+              }
+            ],
+            "source": "serenityPR2"
+          },
+          "statistics": {
+            "cpus_limit": 1.1,
+            "cpus_system_time_secs": 1.17,
+            "cpus_user_time_secs": 3.37,
+            "mem_limit_bytes": 167772160,
+            "mem_rss_bytes": 70983680,
+            "perf": {
+              "duration": 1,
+              "instructions": 4000000000,
+              "timestamp": 1434982917.7405
+            },
+            "timestamp": 1434982917.7405
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR includes all changes made in [ips-signal](https://github.com/mesosphere/serenity/tree/ips-signal), however it leaves IPC detection as current signal. You can easily switch to IPS by changing the static function in https://github.com/mesosphere/serenity/compare/ipc-drop-detection-improvement?expand=1#diff-c87cf158ce468b72d9f5b6af898618b3