### PR TITLE
Refactored AssuranceDetector (added Quorum) and SeniorityStrategy (added interactions with Estimator Valve)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ set(SERENITY_TEST_SOURCES
     src/tests/estimators/estimator_test.cpp
     # Detectors tests WIP.
     # src/tests/filters/detector_test.cpp
-    # src/tests/filters/detectors/assurance_test.cpp
+    src/tests/filters/detectors/assurance_test.cpp
     src/tests/filters/ema_test.cpp
     src/tests/filters/ignore_new_executors_test.cpp
     src/tests/filters/pr_executor_pass_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,8 +107,8 @@ set(SERENITY_SOURCES
     src/filters/executor_age.cpp
     src/observers/qos_correction.cpp
     src/observers/slack_resource.cpp
-        src/observers/strategies/kill_all.cpp
-        src/observers/strategies/seniority.cpp
+    src/observers/strategies/kill_all.cpp
+    src/observers/strategies/seniority.cpp
     src/qos_controller/serenity_controller.cpp
     src/qos_controller/serenity_controller_module.cpp
     src/serenity/agent_utils.cpp
@@ -124,8 +124,6 @@ set(SERENITY_TEST_SOURCES
     src/tests/common/sources/json_source.cpp
     src/tests/controllers/qos_controller_test.cpp
     src/tests/estimators/estimator_test.cpp
-    # Detectors tests WIP.
-    # src/tests/filters/detector_test.cpp
     src/tests/filters/detectors/assurance_test.cpp
     src/tests/filters/ema_test.cpp
     src/tests/filters/ignore_new_executors_test.cpp
@@ -133,8 +131,6 @@ set(SERENITY_TEST_SOURCES
     src/tests/filters/utilization_threshold_test.cpp
     src/tests/filters/valve_test.cpp
     src/tests/pipeline/estimator_pipeline_test.cpp
-    # Detectors tests WIP.
-    # src/tests/pipeline/qos_pipeline_test.cpp
     src/tests/observers/slack_resource_test.cpp
     src/tests/observers/qos_correction_test.cpp
     src/tests/serenity/config_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ set(SERENITY_SOURCES
     src/bus/event_bus.cpp
     src/estimator/serenity_estimator.cpp
     src/estimator/serenity_estimator_module.cpp
-    src/filters/detector.cpp
+    src/filters/contention_detector.cpp
     src/filters/detectors/assurance.cpp
     src/filters/ema.cpp
     src/filters/ignore_new_executors.cpp

--- a/src/bus/event_bus.hpp
+++ b/src/bus/event_bus.hpp
@@ -192,6 +192,15 @@ class StaticEventBus {
     }
   }
 
+  /**
+   * Useful functions for publishing.
+   */
+  static inline void publishOversubscriptionCtrlEvent(bool opened) {
+    OversubscriptionCtrlEventEnvelope envelope;
+    envelope.mutable_message()->set_enable(opened);
+    StaticEventBus::publish<OversubscriptionCtrlEventEnvelope>(envelope);
+  }
+
  private:
   // Private constructor.
   StaticEventBus() {}

--- a/src/filters/contention_detector.cpp
+++ b/src/filters/contention_detector.cpp
@@ -1,15 +1,17 @@
 #include <utility>
 
-#include "filters/detector.hpp"
+#include "contention_detector.hpp"
 
 namespace mesos {
 namespace serenity {
 
-Try<Nothing> DetectorFilter::consume(const ResourceUsage& in) {
+Try<Nothing> ContentionDetectorFilter::consume(const ResourceUsage& in) {
   return this->_detect(DividedResourceUsage(in));
 }
 
-Try<Nothing> DetectorFilter::_detect(const DividedResourceUsage& usage) {
+
+Try<Nothing> ContentionDetectorFilter::_detect(
+    const DividedResourceUsage& usage) {
   std::unique_ptr<ExecutorSet> newSamples(new ExecutorSet());
   Contentions product;
 

--- a/src/filters/contention_detector.hpp
+++ b/src/filters/contention_detector.hpp
@@ -34,11 +34,11 @@ namespace serenity {
  * DetectorFilter is able to check defined value and trigger some contentions
  * on given thresholds.
  */
-class DetectorFilter :
+class ContentionDetectorFilter :
     public Consumer<ResourceUsage>,
     public Producer<Contentions> {
  public:
-  DetectorFilter(
+  ContentionDetectorFilter(
       Consumer<Contentions>* _consumer,
       const lambda::function<usage::GetterFunction>& _valueGetFunction,
       SerenityConfig _detectorConf,
@@ -50,7 +50,7 @@ class DetectorFilter :
       valueGetFunction(_valueGetFunction),
       detectorConf(_detectorConf) {}
 
-  ~DetectorFilter() {}
+  ~ContentionDetectorFilter() {}
 
   Try<Nothing> consume(const ResourceUsage& in) override;
 

--- a/src/filters/detector.hpp
+++ b/src/filters/detector.hpp
@@ -29,7 +29,6 @@
 namespace mesos {
 namespace serenity {
 
-
 /**
  * DetectorFilter is able to check defined value and trigger some contentions
  * on given thresholds.

--- a/src/filters/detector.hpp
+++ b/src/filters/detector.hpp
@@ -35,7 +35,9 @@ namespace serenity {
  * on given thresholds.
  */
 class DetectorFilter :
-    public Consumer<ResourceUsage>, public Producer<Contentions> {
+    public Consumer<ResourceUsage>,
+    public Consumer<BeResourceUsage>,
+    public Producer<Contentions> {
  public:
   DetectorFilter(
       Consumer<Contentions>* _consumer,
@@ -53,6 +55,10 @@ class DetectorFilter :
 
   Try<Nothing> consume(const ResourceUsage& in) override;
 
+  Try<Nothing> consume(const BeResourceUsage& in) override;
+
+  Try<Nothing> __detect();
+
   static const constexpr char* NAME = "Detector";
 
  protected:
@@ -63,6 +69,9 @@ class DetectorFilter :
   // Detections.
   std::unique_ptr<ExecutorMap<std::shared_ptr<BaseDetector>>> detectors;
   SerenityConfig detectorConf;
+
+  Option<ResourceUsage> currentVictimsUsage;
+  Option<ResourceUsage> currentAggressorsUsage;
 };
 
 }  // namespace serenity

--- a/src/filters/detector.hpp
+++ b/src/filters/detector.hpp
@@ -19,6 +19,7 @@
 #include "serenity/executor_map.hpp"
 #include "serenity/executor_set.hpp"
 #include "serenity/serenity.hpp"
+#include "serenity/resource_helper.hpp"
 #include "serenity/wid.hpp"
 
 #include "stout/lambda.hpp"
@@ -35,7 +36,6 @@ namespace serenity {
  */
 class DetectorFilter :
     public Consumer<ResourceUsage>,
-    public Consumer<BeResourceUsage>,
     public Producer<Contentions> {
  public:
   DetectorFilter(
@@ -54,9 +54,7 @@ class DetectorFilter :
 
   Try<Nothing> consume(const ResourceUsage& in) override;
 
-  Try<Nothing> consume(const BeResourceUsage& in) override;
-
-  Try<Nothing> __detect();
+  Try<Nothing> _detect(const DividedResourceUsage& in);
 
   static const constexpr char* NAME = "Detector";
 
@@ -68,9 +66,6 @@ class DetectorFilter :
   // Detections.
   std::unique_ptr<ExecutorMap<std::shared_ptr<BaseDetector>>> detectors;
   SerenityConfig detectorConf;
-
-  Option<ResourceUsage> currentVictimsUsage;
-  Option<ResourceUsage> currentAggressorsUsage;
 };
 
 }  // namespace serenity

--- a/src/filters/detectors/assurance.cpp
+++ b/src/filters/detectors/assurance.cpp
@@ -44,7 +44,6 @@ void AssuranceDetector::recalculateParams() {
 
   // Make sure it does not exceed MAX_CHECKPOINSs option.
   if (checkpoints > this->cfg.getU64(detector::MAX_CHECKPOINTS)) {
-    SERENITY_LOG(WARNING) << "Too wide windowSize.";
     checkpoints = this->cfg.getU64(detector::MAX_CHECKPOINTS);
   }
 

--- a/src/filters/detectors/assurance.cpp
+++ b/src/filters/detectors/assurance.cpp
@@ -1,3 +1,4 @@
+#include <list>
 #include <utility>
 
 #include "filters/detectors/assurance.hpp"
@@ -9,71 +10,109 @@
 namespace mesos {
 namespace serenity {
 
-Result<Detection> AssuranceDetector::processSample(
-    double_t in) {
+void AssuranceDetector::shiftBasePoints() {
+  for (std::list<double_t>::iterator& basePoint : this->basePoints) {
+    basePoint++;
+  }
+}
+
+Detection AssuranceDetector::createContention(double_t severity) {
+  Detection cpd;
+  cpd.severity = severity;
+  SERENITY_LOG(INFO) << " Created contention with severity = "
+                      << cpd.severity;
+}
+
+Result<Detection> AssuranceDetector::processSample(double_t in) {
+  // Fill window.
+  if (in < 0.1)
+    in = 0.1;
   this->window.push_back(in);
 
-  if (this->window.size() < this->cfg.getU64(detector::WINDOW_SIZE)) {
-    return None();  // Only warm up.
-  }
+  Result<Detection> result = this->_processSample(in);
 
-  double_t basePoint = this->window.front();
+  // Always at the end of sample process.
+  this->shiftBasePoints();
   this->window.pop_front();
 
-  if (this->referencePoint.isSome()) {
+  return result;
+}
+
+
+Try<Nothing> AssuranceDetector::reset() {
+  // Return detector to normal state.
+  SERENITY_LOG(INFO) << "Resetting.";
+  this->valueBeforeDrop = None();
+
+  return Nothing();
+}
+
+
+Result<Detection> AssuranceDetector::_processSample(
+    double_t in) {
+
+  if (this->valueBeforeDrop.isSome()) {
     // Check if the signal returned to normal state. (!)
     double_t nearValue =
-      this->cfg.getD(detector::NEAR_FRACTION) * this->referencePoint.get();
-    SERENITY_LOG(INFO) << "Waiting for signal to return to "
-                       << (this->referencePoint.get() - nearValue)
-                       << " (base value) after "
-                       << "corrections. Waiting iteration: "
-                       << referencePointCounter;
-    this->referencePointCounter++;
+      this->cfg.getD(detector::NEAR_FRACTION) * this->valueBeforeDrop.get();
+    SERENITY_LOG(INFO) << "Waiting for signal: "
+                       << in << " to return to: "
+                       << (this->valueBeforeDrop.get() - nearValue)
+                       << "after corrections. ";
     // We want to use reference Base Point instead of base point.
-    basePoint = in;
-    if (in >= (this->referencePoint.get() - nearValue)) {
-      this->referencePoint = None();
+    if (in >= (this->valueBeforeDrop.get() - nearValue)) {
+      this->reset();
       SERENITY_LOG(INFO) << "Signal returned to established state.";
+    } else {
+      // Create contention.
+      return this->createContention(
+        1 * this->cfg.getD(detector::SEVERITY_FRACTION));
     }
   }
 
-  // Current drop fraction indicates how much value has drop in relation to
-  // base point
-  double_t currentDropFraction = 1.0 - (in / basePoint);
+  double_t currentDropFraction = 0;
+  double_t meanValueBeforeDrop = 0;
+  this->dropVotes = 0;
+  std::stringstream basePointValues;
+
+  for (std::list<double_t>::iterator basePoint : this->basePoints) {
+    basePointValues << " " << (double_t)(*basePoint);
+    // Check if drop happened for this basePoint.
+    double_t dropFraction = 1.0 - (in / (*basePoint));
+    if (dropFraction >=
+        this->cfg.getD(detector::FRACTIONAL_THRESHOLD)) {
+      // Vote on drop.
+      this->dropVotes++;
+      currentDropFraction += dropFraction;
+      meanValueBeforeDrop += (double_t)(*basePoint);
+      basePointValues << "[-] ";
+    } else {
+      basePointValues << "[+] ";
+    }
+  }
+
+  if (this->dropVotes > 0) {
+    currentDropFraction /= this->dropVotes;
+    meanValueBeforeDrop /= this->dropVotes;
+  }  // In other cases theses variables == 0.
 
   SERENITY_LOG(INFO)
-  << " inputValue: " << in
-  << " | baseValue = " << basePoint
-  << " | current drop %: " << currentDropFraction * 100
-  << " | threshold %: "
-  << this->cfg.getD(detector::FRACTIONAL_THRESHOLD) * 100;
+  << "{inValue: " << in
+  << " |baseValues:" << basePointValues.str()
+  << " |currentDrop %: " << currentDropFraction * 100
+  << " |threshold %: "
+  << this->cfg.getD(detector::FRACTIONAL_THRESHOLD) * 100
+  << " |dropVotes/quorum: " << this->dropVotes
+  << "/" << this->cfg.getU64(detector::QUORUM)
+  << "}";
 
-  // If drop fraction is higher than threshold or signal did not returned
-  // after cooldown, then trigger contention.
-  if (currentDropFraction > this->cfg.getD(detector::FRACTIONAL_THRESHOLD) ||
-      (this->referencePoint.isSome())) {
-    Detection cpd;
-    if (this->referencePoint.isNone()) {
-      cpd.severity =
-        currentDropFraction * this->cfg.getD(detector::SEVERITY_FRACTION);
-      this->lastSeverity = cpd.severity;
-    } else {
-      cpd.severity =  this->lastSeverity;
-    }
 
-    LOG(INFO) << tag.NAME() << " Created contention with severity = "
-              << cpd.severity;
-
-    this->referencePoint = basePoint;
-    this->referencePointCounter = 0;
-
-    return cpd;
-  }
-
-  if (in < basePoint) {
-    SERENITY_LOG(INFO) << " Found decrease, "
-        "but not significant: " << (currentDropFraction * 100) << "%";
+  // Check if drop obtained minimum number of votes.
+  if (this->dropVotes >= this->cfg.getU64(detector::QUORUM)) {
+    // Create contention.
+    this->valueBeforeDrop = meanValueBeforeDrop;
+    return this->createContention(
+      currentDropFraction * this->cfg.getD(detector::SEVERITY_FRACTION));
   }
 
   return None();

--- a/src/filters/detectors/assurance.hpp
+++ b/src/filters/detectors/assurance.hpp
@@ -29,6 +29,8 @@
 namespace mesos {
 namespace serenity {
 
+#define ASSURANCE_DETECTOR_NAME "AssuranceDetector";
+
 class AssuranceDetectorConfig : public SerenityConfig {
  public:
   AssuranceDetectorConfig() {}
@@ -39,7 +41,7 @@ class AssuranceDetectorConfig : public SerenityConfig {
   }
 
   void initDefaults() {
-    this->fields[detector::DETECTOR_TYPE] = "AssuranceDetector";
+    this->fields[detector::DETECTOR_TYPE] = ASSURANCE_DETECTOR_NAME;
     //! uint64_t
     //! How far in the past we look.
     this->fields[detector::WINDOW_SIZE] =
@@ -104,9 +106,17 @@ class AssuranceDetector : public BaseDetector {
   explicit AssuranceDetector(
       const Tag& _tag,
       const SerenityConfig& _config)
-    : BaseDetector(_tag, AssuranceDetectorConfig(_config)),
+    : BaseDetector(_tag),
       valueBeforeDrop(None()),
       quorumNum(0) {
+    SerenityConfig config = AssuranceDetectorConfig(_config);
+    this->cfgWindowSize = config.getU64(detector::WINDOW_SIZE);
+    this->cfgMaxCheckpoints = config.getU64(detector::MAX_CHECKPOINTS);
+    this->cfgQuroum = config.getD(detector::QUORUM);
+    this->cfgFractionalThreshold = config.getD(detector::FRACTIONAL_THRESHOLD);
+    this->cfgNearFraction = config.getD(detector::NEAR_FRACTION);
+    this->cfgSeverityFraction = config.getD(detector::SEVERITY_FRACTION);
+
     this->recalculateParams();
   }
 
@@ -131,8 +141,6 @@ class AssuranceDetector : public BaseDetector {
    */
   void recalculateParams();
 
-  static const constexpr char* NAME = "AssuranceDetector";
-
  protected:
   std::list<double_t> window;
   std::list<std::list<double_t>::iterator> basePoints;
@@ -140,8 +148,17 @@ class AssuranceDetector : public BaseDetector {
   // If none then there was no drop.
   Option<double_t> valueBeforeDrop;
 
-  int32_t dropVotes;
-  int32_t quorumNum;
+  uint32_t dropVotes;
+  uint32_t quorumNum;
+
+
+  // cfg parameters.
+  uint64_t cfgWindowSize;
+  uint64_t cfgMaxCheckpoints;
+  double_t cfgQuroum;
+  double_t cfgFractionalThreshold;
+  double_t cfgSeverityFraction;
+  double_t cfgNearFraction;
 };
 
 

--- a/src/filters/detectors/assurance.hpp
+++ b/src/filters/detectors/assurance.hpp
@@ -4,6 +4,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <iostream>
 #include <type_traits>
 
 #include "filters/detectors/base.hpp"
@@ -57,14 +58,25 @@ class AssuranceDetectorConfig : public SerenityConfig {
     //! previous state after drop.
     this->fields[detector::NEAR_FRACTION] =
       detector::DEFAULT_NEAR_FRACTION;
+
+    //! Number of checkpoints we will have in our assurance detector.
+    //! Checkpoints are the reference (base) points which we refer to in the
+    //! past when detecting drop or not. It needs to be 0 < WINDOW_SIZE
+    this->fields[detector::CHECKPOINTS] =
+      detector::DEFAULT_CHECKPOINTS;
+
+    //! Number of checkpoints' votes that important decision needs to obtain.
+    this->fields[detector::QUORUM] =
+      detector::DEFAULT_QUORUM;
   }
 };
 
 
 /**
  * Dynamic implementation of sequential change point detection.
- * Algorithm steps:
- * - Warm up phase: wait "windowsSize" iterations.
+ *
+ * There is no warm-up phase - values starts as 0.
+ * Algorithm steps: TODO:
  * - fetch base point value from (currentIteration - "windowsSize").
  * - Check if new value drops more than fraction of basePoint specified
  *   in fractionalThreshold option.
@@ -79,18 +91,74 @@ class AssuranceDetector : public BaseDetector {
       const Tag& _tag,
       const SerenityConfig& _config)
     : BaseDetector(_tag, AssuranceDetectorConfig(_config)),
-      referencePoint(None()),
-      referencePointCounter(0),
-      lastSeverity(0) {}
+      valueBeforeDrop(None()) {
+    // Validation phase.
+
+    if (this->cfg.getU64(detector::QUORUM) >
+        this->cfg.getU64(detector::CHECKPOINTS)) {
+      SERENITY_LOG(WARNING) << detector::QUORUM << "param cannot be less "
+                            << "than " << detector::CHECKPOINTS;
+      this->cfg.set(detector::QUORUM, this->cfg.getU64(detector::CHECKPOINTS));
+    }
+
+    // TODO(bplotka): Apply different ways to achieve points.
+    // Eg. T-n, T-2n, T-4n, T-8n..
+    // Currently we base on const checkPointInterval.
+    if (this->cfg.getU64(detector::CHECKPOINTS) == 0) {
+      SERENITY_LOG(WARNING) << detector::CHECKPOINTS << "param cannot be zero.";
+      checkPointInterval = 1;
+    } else {
+      checkPointInterval =
+        this->cfg.getU64(detector::WINDOW_SIZE)/
+        this->cfg.getU64(detector::CHECKPOINTS);
+
+      if (checkPointInterval == 0) {
+        SERENITY_LOG(WARNING) << detector::WINDOW_SIZE << " parameter "
+        << "is required to be higher than " << detector::CHECKPOINTS
+        << "param. Assigning: " << detector::CHECKPOINTS << " = "
+        << detector::WINDOW_SIZE;
+        checkPointInterval = 1;
+      }
+    }
+
+    // Init window with zeros and choose base points.
+    for (int i = 1; i <= this->cfg.getU64(detector::WINDOW_SIZE); i++) {
+      this->window.push_back(0.000001);
+      if (checkPointInterval == 1 || i % checkPointInterval == 1) {
+        if (basePoints.size() < this->cfg.getU64(detector::CHECKPOINTS)) {
+          basePoints.push_back(--this->window.end());
+        }
+      }
+    }
+  }
+
+  Result<Detection> _processSample(double_t in);
 
   virtual Result<Detection> processSample(double_t in);
 
+  virtual Try<Nothing> reset();
+
+  /**
+   * Move each base point to next iterator.
+   */
+  void shiftBasePoints();
+
+  /**
+   * Contention Factory.
+   */
+  Detection createContention(double_t severity);
+
   static const constexpr char* NAME = "AssuranceDetector";
+
  protected:
+  int64_t checkPointInterval = 0;
   std::list<double_t> window;
-  Option<double_t> referencePoint;
-  uint64_t referencePointCounter;
-  double_t lastSeverity;
+  std::list<std::list<double_t>::iterator> basePoints;
+
+  // If none then there was no drop.
+  Option<double_t> valueBeforeDrop;
+
+  int32_t dropVotes;
 };
 
 

--- a/src/filters/detectors/base.hpp
+++ b/src/filters/detectors/base.hpp
@@ -15,7 +15,9 @@ namespace mesos {
 namespace serenity {
 
 struct Detection {
-  double_t severity;
+  Detection() : severity(None()) {}
+
+  Option<double_t> severity;
 };
 
 
@@ -36,10 +38,10 @@ class BaseDetector {
 
   virtual Try<Nothing> reset() { return Nothing(); }
 
+  SerenityConfig cfg;
+
  protected:
   const Tag tag;
-  SerenityConfig cfg;
-  uint64_t contentionCooldownCounter = 0;
 };
 
 

--- a/src/filters/detectors/base.hpp
+++ b/src/filters/detectors/base.hpp
@@ -4,7 +4,6 @@
 #include <memory>
 #include <string>
 
-#include "serenity/config.hpp"
 #include "serenity/serenity.hpp"
 
 #include "stout/nothing.hpp"
@@ -27,9 +26,7 @@ struct Detection {
  */
 class BaseDetector {
  public:
-  explicit BaseDetector(const Tag& _tag,
-                        const SerenityConfig _config)
-    : tag(_tag), cfg(_config) {
+  explicit BaseDetector(const Tag& _tag) : tag(_tag) {
   }
 
   static std::shared_ptr<BaseDetector> makeDetector(std::string);
@@ -37,8 +34,6 @@ class BaseDetector {
   virtual Result<Detection> processSample(double_t in) { return None(); }
 
   virtual Try<Nothing> reset() { return Nothing(); }
-
-  SerenityConfig cfg;
 
  protected:
   const Tag tag;

--- a/src/filters/detectors/base.hpp
+++ b/src/filters/detectors/base.hpp
@@ -34,6 +34,8 @@ class BaseDetector {
 
   virtual Result<Detection> processSample(double_t in) { return None(); }
 
+  virtual Try<Nothing> reset() { return Nothing(); }
+
  protected:
   const Tag tag;
   SerenityConfig cfg;

--- a/src/filters/pr_executor_pass.cpp
+++ b/src/filters/pr_executor_pass.cpp
@@ -6,10 +6,8 @@ namespace mesos {
 namespace serenity {
 
 Try<Nothing> PrExecutorPassFilter::consume(const ResourceUsage& in) {
-  ResourceUsage prProduct;
-  prProduct.mutable_total()->CopyFrom(in.total());
-  BeResourceUsage beProduct;
-  beProduct.mutable_usage()->mutable_total()->CopyFrom(in.total());
+  ResourceUsage product;
+  product.mutable_total()->CopyFrom(in.total());
   for (ResourceUsage_Executor inExec : in.executors()) {
     if (!inExec.has_executor_info()) {
       LOG(ERROR) << name << "Executor <unknown>"
@@ -28,20 +26,15 @@ Try<Nothing> PrExecutorPassFilter::consume(const ResourceUsage& in) {
     Resources allocated(inExec.allocated());
     // Check if task uses revocable resources.
     if (!allocated.revocable().empty()) {
-      // Add an BE executor.
-      ResourceUsage_Executor* outExec =
-        beProduct.mutable_usage()->mutable_executors()->Add();
-      outExec->CopyFrom(inExec);
-    } else {
-      // Add an PR executor.
-      ResourceUsage_Executor* outExec = prProduct.mutable_executors()->Add();
-      outExec->CopyFrom(inExec);
+      continue;
     }
+
+    // Add an PR executor.
+    ResourceUsage_Executor* outExec = product.mutable_executors()->Add();
+    outExec->CopyFrom(inExec);
   }
 
-  Producer<ResourceUsage>::produce(prProduct);
-
-  Producer<BeResourceUsage>::produce(beProduct);
+  produce(product);
 
   return Nothing();
 }

--- a/src/filters/pr_executor_pass.hpp
+++ b/src/filters/pr_executor_pass.hpp
@@ -16,37 +16,8 @@
 namespace mesos {
 namespace serenity {
 
-inline std::list<ResourceUsage_Executor> filterPrExecutors(
-  ResourceUsage usage) {
-  std::list<ResourceUsage_Executor> beExecutors;
-  for (ResourceUsage_Executor inExec : usage.executors()) {
-    if (!inExec.has_executor_info()) {
-      LOG(ERROR) << "Executor <unknown>"
-      << " does not include executor_info";
-      // Filter out these executors.
-      continue;
-    }
-    if (inExec.allocated().size() == 0) {
-      LOG(ERROR) << "Executor "
-      << inExec.executor_info().executor_id().value()
-      << " does not include allocated resources.";
-      // Filter out these executors.
-      continue;
-    }
-
-    Resources allocated(inExec.allocated());
-    // Check if task uses revocable resources.
-    if (!allocated.revocable().empty())
-      beExecutors.push_back(inExec);
-  }
-
-  return beExecutors;
-}
-
 /**
  * Filter retaining ResourceUsage for production executors only.
- * Additionally it can also produce ResourceUsage with Be tasks only
- * (as BeResourceUsage).
  */
 class PrExecutorPassFilter :
     public Consumer<ResourceUsage>,

--- a/src/filters/pr_executor_pass.hpp
+++ b/src/filters/pr_executor_pass.hpp
@@ -78,8 +78,7 @@ inline std::list<ResourceUsage_Executor> filterBeExecutors(
  */
 class PrExecutorPassFilter :
     public Consumer<ResourceUsage>,
-    public Producer<ResourceUsage>,
-    public Producer<BeResourceUsage> {
+    public Producer<ResourceUsage> {
  public:
   explicit PrExecutorPassFilter(Consumer<ResourceUsage>* _consumer)
       : Producer<ResourceUsage>(_consumer) {}
@@ -87,11 +86,6 @@ class PrExecutorPassFilter :
   ~PrExecutorPassFilter() {}
 
   Try<Nothing> consume(const ResourceUsage& in);
-
-  template<class T>
-  Try<Nothing> addConsumer(Consumer<T>* consumer) override {
-    return Producer<T>::addConsumer(consumer);
-  }
 
   static constexpr const char* name = "[Serenity] PrExecutorPasFilter: ";
 };

--- a/src/filters/pr_executor_pass.hpp
+++ b/src/filters/pr_executor_pass.hpp
@@ -43,34 +43,6 @@ inline std::list<ResourceUsage_Executor> filterPrExecutors(
   return beExecutors;
 }
 
-
-inline std::list<ResourceUsage_Executor> filterBeExecutors(
-  ResourceUsage usage) {
-  std::list<ResourceUsage_Executor> prExecutors;
-  for (ResourceUsage_Executor inExec : usage.executors()) {
-    if (!inExec.has_executor_info()) {
-      LOG(ERROR) << "Executor <unknown>"
-      << " does not include executor_info";
-      // Filter out these executors.
-      continue;
-    }
-    if (inExec.allocated().size() == 0) {
-      LOG(ERROR) << "Executor "
-      << inExec.executor_info().executor_id().value()
-      << " does not include allocated resources.";
-      // Filter out these executors.
-      continue;
-    }
-
-    Resources allocated(inExec.allocated());
-    // Check if task uses revocable resources.
-    if (allocated.revocable().empty())
-      prExecutors.push_back(inExec);
-  }
-
-  return prExecutors;
-}
-
 /**
  * Filter retaining ResourceUsage for production executors only.
  * Additionally it can also produce ResourceUsage with Be tasks only

--- a/src/messages/serenity.hpp
+++ b/src/messages/serenity.hpp
@@ -19,13 +19,15 @@ using Contentions = std::list<mesos::Contention>;
 using QoSCorrections = std::list<slave::QoSCorrection>;
 
 inline Contention createCpuContention(
-    double_t severity,
+    Option<double_t> severity,
     WorkID victim,
     double_t timestamp,
     Option<WorkID> aggressor = None()) {
   Contention contention;
   contention.set_type(Contention_Type_CPU);
-  contention.set_severity(severity);
+  if (severity.isSome()) {
+    contention.set_severity(severity.get());
+  }
   contention.set_timestamp(timestamp);
   contention.mutable_victim()->CopyFrom(victim);
   if (aggressor.isSome())

--- a/src/messages/serenity.proto
+++ b/src/messages/serenity.proto
@@ -20,13 +20,6 @@ message OversubscriptionCtrlEventEnvelope {
   optional OversubscriptionCtrlEvent message = 1;
 }
 
-/**
- * Necessary message for separating Be jobs & Pr jobs.
- * TODO(bplotka): Implement more dynamic method for data transitions.
- */
-message BeResourceUsage {
-  required ResourceUsage usage = 1;
-}
 
 /**
  * Necessary union to define job.

--- a/src/messages/serenity.proto
+++ b/src/messages/serenity.proto
@@ -21,6 +21,14 @@ message OversubscriptionCtrlEventEnvelope {
 }
 
 /**
+ * Necessary message for separating Be jobs & Pr jobs.
+ * TODO(bplotka): Implement more dynamic method for data transitions.
+ */
+message BeResourceUsage {
+  required ResourceUsage usage = 1;
+}
+
+/**
  * Necessary union to define job.
  * Currently we cannot specify individual task.
  * NOTE: Framework id must be set for the specified executor.

--- a/src/observers/strategies/base.hpp
+++ b/src/observers/strategies/base.hpp
@@ -13,7 +13,6 @@
 
 #include "messages/serenity.hpp"
 
-#include "serenity/config.hpp"
 #include "serenity/serenity.hpp"
 
 #include "stout/try.hpp"
@@ -34,13 +33,10 @@ using RevocationStrategyFunction = Try<QoSCorrections>
  */
 class RevocationStrategy {
  public:
-  RevocationStrategy(const Tag& _tag,
-                     const SerenityConfig& _config = SerenityConfig())
-    : tag(_tag), config(_config) {}
+  explicit RevocationStrategy(const Tag& _tag) : tag(_tag) {}
 
   virtual RevocationStrategyFunction decide = 0;
  protected:
-  SerenityConfig config;
   const Tag tag;
 };
 

--- a/src/observers/strategies/base.hpp
+++ b/src/observers/strategies/base.hpp
@@ -37,34 +37,6 @@ class RevocationStrategy {
   virtual RevocationStrategyFunction decide = 0;
 };
 
-
-inline std::list<ResourceUsage_Executor> filterPrExecutors(
-  ResourceUsage usage) {
-  std::list<ResourceUsage_Executor> beExecutors;
-  for (ResourceUsage_Executor inExec : usage.executors()) {
-    if (!inExec.has_executor_info()) {
-      LOG(ERROR) << "Executor <unknown>"
-      << " does not include executor_info";
-      // Filter out these executors.
-      continue;
-    }
-    if (inExec.allocated().size() == 0) {
-      LOG(ERROR) << "Executor "
-      << inExec.executor_info().executor_id().value()
-      << " does not include allocated resources.";
-      // Filter out these executors.
-      continue;
-    }
-
-    Resources allocated(inExec.allocated());
-    // Check if task uses revocable resources.
-    if (!allocated.revocable().empty())
-      beExecutors.push_back(inExec);
-  }
-
-  return beExecutors;
-}
-
 }  // namespace serenity
 }  // namespace mesos
 

--- a/src/observers/strategies/base.hpp
+++ b/src/observers/strategies/base.hpp
@@ -34,7 +34,14 @@ using RevocationStrategyFunction = Try<QoSCorrections>
  */
 class RevocationStrategy {
  public:
+  RevocationStrategy(const Tag& _tag,
+                     const SerenityConfig& _config = SerenityConfig())
+    : tag(_tag), config(_config) {}
+
   virtual RevocationStrategyFunction decide = 0;
+ protected:
+  SerenityConfig config;
+  const Tag tag;
 };
 
 }  // namespace serenity

--- a/src/observers/strategies/kill_all.cpp
+++ b/src/observers/strategies/kill_all.cpp
@@ -1,5 +1,7 @@
 #include <list>
 
+#include "filters/pr_executor_pass.hpp"
+
 #include "observers/strategies/kill_all.hpp"
 
 namespace mesos {

--- a/src/observers/strategies/kill_all.cpp
+++ b/src/observers/strategies/kill_all.cpp
@@ -1,8 +1,8 @@
 #include <list>
 
-#include "filters/pr_executor_pass.hpp"
-
 #include "observers/strategies/kill_all.hpp"
+
+#include "serenity/resource_helper.hpp"
 
 namespace mesos {
 namespace serenity {
@@ -18,7 +18,7 @@ Try<QoSCorrections> KillAllStrategy::decide(
 
   // List of BE executors.
   list<ResourceUsage_Executor> aggressors =
-    filterPrExecutors(currentUsage);
+    DividedResourceUsage::filterPrExecutors(currentUsage);
 
   // Create QoSCorrection from aggressors list.
   for (auto aggressorToKill : aggressors) {

--- a/src/observers/strategies/kill_all.hpp
+++ b/src/observers/strategies/kill_all.hpp
@@ -11,6 +11,9 @@ namespace serenity {
  */
 class KillAllStrategy : public RevocationStrategy {
  public:
+  KillAllStrategy() :
+    RevocationStrategy(Tag(QOS_CONTROLLER, "KillAllStrategy")) {}
+
   RevocationStrategyFunction decide;
 };
 

--- a/src/observers/strategies/seniority.cpp
+++ b/src/observers/strategies/seniority.cpp
@@ -3,9 +3,9 @@
 
 #include "bus/event_bus.hpp"
 
-#include "filters/pr_executor_pass.hpp"
-
 #include "observers/strategies/seniority.hpp"
+
+#include "serenity/resource_helper.hpp"
 
 namespace mesos {
 namespace serenity {
@@ -76,7 +76,7 @@ Try<QoSCorrections> SeniorityStrategy::decide(
 
   // List of BE executors.
   list<ResourceUsage_Executor> possibleAggressors =
-    filterPrExecutors(currentUsage);
+    DividedResourceUsage::filterPrExecutors(currentUsage);
 
   // Aggressors to be killed. (empty for now).
   std::list<slave::QoSCorrection_Kill> aggressorsToKill;

--- a/src/observers/strategies/seniority.cpp
+++ b/src/observers/strategies/seniority.cpp
@@ -13,12 +13,6 @@ namespace serenity {
 using std::list;
 using std::pair;
 
-inline void setOpenEstimatorPipeline(bool opened) {
-  OversubscriptionCtrlEventEnvelope envelope;
-  envelope.mutable_message()->set_enable(opened);
-  StaticEventBus::publish<OversubscriptionCtrlEventEnvelope>(envelope);
-}
-
 Try<QoSCorrections> SeniorityStrategy::decide(
     ExecutorAgeFilter* ageFilter,
     const Contentions& currentContentions,
@@ -34,7 +28,7 @@ Try<QoSCorrections> SeniorityStrategy::decide(
 
     // Open Estimator Pipeline.
     if (estimatorDisabled) {
-      setOpenEstimatorPipeline(true);
+      StaticEventBus::publishOversubscriptionCtrlEvent(true);
       estimatorDisabled = false;
     }
 
@@ -67,7 +61,7 @@ Try<QoSCorrections> SeniorityStrategy::decide(
   cooldownCounter = this->cfgCooldownTime;
   // Disable Estimator pipeline.
   if (!estimatorDisabled) {
-    setOpenEstimatorPipeline(false);
+    StaticEventBus::publishOversubscriptionCtrlEvent(false);
     estimatorDisabled = true;
   }
 

--- a/src/observers/strategies/seniority.cpp
+++ b/src/observers/strategies/seniority.cpp
@@ -64,7 +64,7 @@ Try<QoSCorrections> SeniorityStrategy::decide(
 
   // ---!!!--- Contention spotted - start new cooldown. ---!!!---
   // TODO(bplotka): Change cooldownTime dynamically (learninig).
-  cooldownCounter = cooldownTime;
+  cooldownCounter = this->cfgCooldownTime;
   // Disable Estimator pipeline.
   if (!estimatorDisabled) {
     setOpenEstimatorPipeline(false);
@@ -106,7 +106,7 @@ Try<QoSCorrections> SeniorityStrategy::decide(
     if (contention.has_severity()) {
       meanSeverity += contention.severity();
     } else {
-      meanSeverity += this->defaultSeverity;
+      meanSeverity += this->cfgDefaultSeverity;
     }
   }
 

--- a/src/observers/strategies/seniority.cpp
+++ b/src/observers/strategies/seniority.cpp
@@ -20,10 +20,9 @@ inline void setOpenEstimatorPipeline(bool opened) {
 }
 
 Try<QoSCorrections> SeniorityStrategy::decide(
-  ExecutorAgeFilter* ageFilter,
-  const Contentions& currentContentions,
-  const ResourceUsage& currentUsage) {
-
+    ExecutorAgeFilter* ageFilter,
+    const Contentions& currentContentions,
+    const ResourceUsage& currentUsage) {
   if (currentContentions.empty()) {
     // No contentions happened.
     // It means that no interference happens or just there are no BE tasks.

--- a/src/observers/strategies/seniority.cpp
+++ b/src/observers/strategies/seniority.cpp
@@ -1,6 +1,8 @@
 #include <list>
 #include <utility>
 
+#include "filters/pr_executor_pass.hpp"
+
 #include "observers/strategies/seniority.hpp"
 
 namespace mesos {
@@ -53,7 +55,7 @@ Try<QoSCorrections> SeniorityStrategy::decide(
   }
   LOG(INFO) << "MeanSeverity: " << meanSeverity;
   // TODO(nnielsen): Made gross assumption about homogenous best-effort tasks.
-  // TODO(nnielsen): Instead of severity, we need taget values (corrections may
+  // TODO(nnielsen): Instead of severity, we need target values (corrections may
   // not have the desired effect). Keep correcting until we have 0 BE tasks.
   size_t killCount = possibleAggressors.size() * meanSeverity;
   if (killCount == 0 && (possibleAggressors.size() * meanSeverity) > 0) {

--- a/src/observers/strategies/seniority.hpp
+++ b/src/observers/strategies/seniority.hpp
@@ -22,10 +22,15 @@ class SeniorityConfig : public SerenityConfig {
   }
 
   void initDefaults() {
+    // uint64_t
     // Specify the initial value of iterations we should wait until
     // we create new correction.
     this->fields[decider::CONTENTION_COOLDOWN] =
       decider::DEFAULT_CONTENTION_COOLDOWN;
+
+    // double_t
+    this->fields[decider::STARTING_SEVERITY] =
+      decider::DEFAULT_STARTING_SEVERITY;
   }
 };
 
@@ -34,16 +39,29 @@ class SeniorityConfig : public SerenityConfig {
  * Checks contentions and choose executors to kill.
  * Currently it calculates mean contention and based on that estimates how
  * many executors we should kill. Executors are sorted by age.
+ *
+ * It also steers the valve filter using EventBus.
  */
 class SeniorityStrategy : public RevocationStrategy {
  public:
   explicit SeniorityStrategy(const SerenityConfig& _config)
-      : config(SeniorityConfig(_config))  {}
+      : RevocationStrategy(
+          Tag(QOS_CONTROLLER, "SeniorityStrategy"),
+          SeniorityConfig(_config)),
+        cooldownCounter(None()),
+        cooldownTime(config.getU64(decider::CONTENTION_COOLDOWN)),
+        defaultSeverity(config.getD(decider::STARTING_SEVERITY)),
+        estimatorDisabled(false) {}
 
   RevocationStrategyFunction decide;
 
  private:
-  const SerenityConfig config;
+  bool estimatorDisabled;
+
+  Option<uint64_t> cooldownCounter;
+  uint64_t cooldownTime;
+
+  double_t defaultSeverity;
 };
 
 }  // namespace serenity

--- a/src/observers/strategies/seniority.hpp
+++ b/src/observers/strategies/seniority.hpp
@@ -5,6 +5,7 @@
 
 #include "observers/strategies/base.hpp"
 
+#include "serenity/config.hpp"
 #include "serenity/wid.hpp"
 
 namespace mesos {
@@ -45,13 +46,13 @@ class SeniorityConfig : public SerenityConfig {
 class SeniorityStrategy : public RevocationStrategy {
  public:
   explicit SeniorityStrategy(const SerenityConfig& _config)
-      : RevocationStrategy(
-          Tag(QOS_CONTROLLER, "SeniorityStrategy"),
-          SeniorityConfig(_config)),
+      : RevocationStrategy(Tag(QOS_CONTROLLER, "SeniorityStrategy")),
         cooldownCounter(None()),
-        cooldownTime(config.getU64(decider::CONTENTION_COOLDOWN)),
-        defaultSeverity(config.getD(decider::STARTING_SEVERITY)),
-        estimatorDisabled(false) {}
+        estimatorDisabled(false) {
+    SerenityConfig config = SeniorityConfig(_config);
+    this->cfgCooldownTime = config.getU64(decider::CONTENTION_COOLDOWN);
+    this->cfgDefaultSeverity = config.getD(decider::STARTING_SEVERITY);
+  }
 
   RevocationStrategyFunction decide;
 
@@ -59,9 +60,10 @@ class SeniorityStrategy : public RevocationStrategy {
   bool estimatorDisabled;
 
   Option<uint64_t> cooldownCounter;
-  uint64_t cooldownTime;
 
-  double_t defaultSeverity;
+  // cfg parameters.
+  uint64_t cfgCooldownTime;
+  double_t cfgDefaultSeverity;
 };
 
 }  // namespace serenity

--- a/src/pipeline/qos_pipeline.hpp
+++ b/src/pipeline/qos_pipeline.hpp
@@ -122,6 +122,9 @@ class CpuQoSPipeline : public QoSControllerPipeline {
     // QoSCorrection needs ResourceUsage as well.
     valveFilter.addConsumer(&qoSCorrectionObserver);
 
+    // ipcDropFilter needs BeResourceUsage as well.
+    prExecutorPassFilter.addConsumer<BeResourceUsage>(&ipcDropFilter);
+
     // Setup Time Series export
     if (conf.getB(ENABLED_VISUALISATION)) {
       this->addConsumer(&rawResourcesExporter);

--- a/src/pipeline/qos_pipeline.hpp
+++ b/src/pipeline/qos_pipeline.hpp
@@ -1,7 +1,7 @@
 #ifndef SERENITY_QOS_PIPELINE_HPP
 #define SERENITY_QOS_PIPELINE_HPP
 
-#include "filters/detector.hpp"
+#include "filters/contention_detector.hpp"
 #include "filters/ema.hpp"
 #include "filters/executor_age.hpp"
 #include "filters/pr_executor_pass.hpp"
@@ -98,7 +98,7 @@ class CpuQoSPipeline : public QoSControllerPipeline {
       ipcDropFilter(
           &qoSCorrectionObserver,
           usage::getEmaIpc,
-          conf[DetectorFilter::NAME],
+          conf[ContentionDetectorFilter::NAME],
           Tag(QOS_CONTROLLER, "IPC detectorFilter")),
       emaFilter(
           &ipcDropFilter,
@@ -136,7 +136,7 @@ class CpuQoSPipeline : public QoSControllerPipeline {
   // --- Filters ---
   ExecutorAgeFilter ageFilter;
   EMAFilter emaFilter;
-  DetectorFilter ipcDropFilter;
+  ContentionDetectorFilter ipcDropFilter;
   ValveFilter valveFilter;
 
   // --- Observers ---

--- a/src/serenity/default_vars.hpp
+++ b/src/serenity/default_vars.hpp
@@ -36,6 +36,10 @@ const constexpr char* SEVERITY_FRACTION = "SEVERITY_FRACTION";
 constexpr double_t DEFAULT_SEVERITY_FRACTION = 0.4;
 const constexpr char* NEAR_FRACTION = "NEAR_FRACTION";
 constexpr double_t DEFAULT_NEAR_FRACTION = 0.1;
+const constexpr char* CHECKPOINTS = "CHECKPOINTS";
+constexpr uint64_t DEFAULT_CHECKPOINTS = 3;
+const constexpr char* QUORUM = "QUORUM";
+constexpr uint64_t DEFAULT_QUORUM = 3;
 }  // namespace detector
 
 namespace slack_observer {

--- a/src/serenity/default_vars.hpp
+++ b/src/serenity/default_vars.hpp
@@ -25,7 +25,6 @@ const constexpr char* ALPHA = "ALPHA";
 constexpr double_t DEFAULT_ALPHA = 0.2;
 }  // namespace ema
 
-
 namespace detector {
 const constexpr char* DETECTOR_TYPE = "DETECTOR_TYPE";
 const constexpr char* WINDOW_SIZE = "WINDOW_SIZE";
@@ -33,13 +32,15 @@ constexpr uint64_t DEFAULT_WINDOW_SIZE = 10;
 const constexpr char* FRACTIONAL_THRESHOLD = "FRACTIONAL_THRESHOLD";
 constexpr double_t DEFAULT_FRACTIONAL_THRESHOLD = 0.5;
 const constexpr char* SEVERITY_FRACTION = "SEVERITY_FRACTION";
-constexpr double_t DEFAULT_SEVERITY_FRACTION = 0.4;
+constexpr double_t DEFAULT_SEVERITY_FRACTION = -1;
 const constexpr char* NEAR_FRACTION = "NEAR_FRACTION";
 constexpr double_t DEFAULT_NEAR_FRACTION = 0.1;
-const constexpr char* CHECKPOINTS = "CHECKPOINTS";
-constexpr uint64_t DEFAULT_CHECKPOINTS = 3;
+const constexpr char* MAX_CHECKPOINTS = "MAX_CHECKPOINTS";
+constexpr uint64_t DEFAULT_MAX_CHECKPOINTS = 3;
 const constexpr char* QUORUM = "QUORUM";
-constexpr uint64_t DEFAULT_QUORUM = 3;
+constexpr double_t DEFAULT_QUORUM = 0.70;
+
+constexpr double_t DEFAULT_START_VALUE = 0.00001;
 }  // namespace detector
 
 namespace slack_observer {
@@ -58,6 +59,8 @@ constexpr uint32_t DEFAULT_THRESHOLD_SEC = 5 * 60;  // !< Five minutes.
 namespace decider {
 const constexpr char* CONTENTION_COOLDOWN = "CONTENTION_COOLDOWN";
 constexpr uint64_t DEFAULT_CONTENTION_COOLDOWN = 10;
+const constexpr char* STARTING_SEVERITY = "STARTING_SEVERITY";
+constexpr double_t DEFAULT_STARTING_SEVERITY = 0.1;
 }  // namespace decider
 
 }  // namespace serenity

--- a/src/serenity/resource_helper.hpp
+++ b/src/serenity/resource_helper.hpp
@@ -1,0 +1,48 @@
+#ifndef SERENITY_RESOURCE_HELPER_HPP
+#define SERENITY_RESOURCE_HELPER_HPP
+
+#include <list>
+
+#include "mesos/mesos.hpp"
+#include "mesos/resources.hpp"
+
+namespace mesos {
+namespace serenity {
+
+class DividedResourceUsage {
+public:
+  DividedResourceUsage(const ResourceUsage& _usage) {
+    usage.CopyFrom(_usage);
+
+    for (ResourceUsage_Executor executor : usage.executors()) {
+      // Check if task uses revocable resources.
+      Resources allocated(executor.allocated());
+      if (allocated.revocable().empty()) {
+        pr.push_back(executor);
+      } else {
+        be.push_back(executor);
+      }
+    }
+  }
+
+  const std::list<ResourceUsage_Executor>& prExecutors() const {
+    return this->pr;
+  }
+
+  const std::list<ResourceUsage_Executor>& beExecutors() const {
+    return this->be;
+  }
+
+  const Resources& total() const {
+    this->usage.total();
+  }
+
+protected:
+  std::list<ResourceUsage_Executor> pr, be;
+  ResourceUsage usage;
+};
+
+}  // namespace serenity
+}  // namespace mesos
+
+#endif  // SERENITY_RESOURCE_HELPER_HPP

--- a/src/serenity/resource_helper.hpp
+++ b/src/serenity/resource_helper.hpp
@@ -10,8 +10,8 @@ namespace mesos {
 namespace serenity {
 
 class DividedResourceUsage {
-public:
-  DividedResourceUsage(const ResourceUsage& _usage) {
+ public:
+  explicit DividedResourceUsage(const ResourceUsage& _usage) {
     usage.CopyFrom(_usage);
 
     for (ResourceUsage_Executor executor : usage.executors()) {
@@ -37,7 +37,7 @@ public:
     this->usage.total();
   }
 
-protected:
+ protected:
   std::list<ResourceUsage_Executor> pr, be;
   ResourceUsage usage;
 };

--- a/src/tests/common/config_helper.hpp
+++ b/src/tests/common/config_helper.hpp
@@ -11,14 +11,14 @@ namespace tests {
 
 inline SerenityConfig createAssuranceDetectorCfg(
     const uint64_t windowSize,
-    const uint64_t checkpoints,
+    const uint64_t maxCheckpoints,
     const double_t fractionalThreshold,
     const double_t severityLvl = detector::DEFAULT_SEVERITY_FRACTION,
     const double_t nearLvl = detector::DEFAULT_NEAR_FRACTION,
-    const uint64_t quorum = detector::DEFAULT_QUORUM) {
+    const double_t quorum = detector::DEFAULT_QUORUM) {
   SerenityConfig cfg;
   cfg.set(detector::WINDOW_SIZE, windowSize);
-  cfg.set(detector::CHECKPOINTS, checkpoints);
+  cfg.set(detector::MAX_CHECKPOINTS, maxCheckpoints);
   cfg.set(detector::FRACTIONAL_THRESHOLD, fractionalThreshold);
   cfg.set(detector::SEVERITY_FRACTION, severityLvl);
   cfg.set(detector::NEAR_FRACTION, nearLvl);

--- a/src/tests/common/config_helper.hpp
+++ b/src/tests/common/config_helper.hpp
@@ -11,15 +11,18 @@ namespace tests {
 
 inline SerenityConfig createAssuranceDetectorCfg(
     const uint64_t windowSize,
-    const uint64_t contentionCooldown,
+    const uint64_t checkpoints,
     const double_t fractionalThreshold,
     const double_t severityLvl = detector::DEFAULT_SEVERITY_FRACTION,
-    const double_t nearLvl = detector::DEFAULT_NEAR_FRACTION) {
+    const double_t nearLvl = detector::DEFAULT_NEAR_FRACTION,
+    const uint64_t quorum = detector::DEFAULT_QUORUM) {
   SerenityConfig cfg;
   cfg.set(detector::WINDOW_SIZE, windowSize);
+  cfg.set(detector::CHECKPOINTS, checkpoints);
   cfg.set(detector::FRACTIONAL_THRESHOLD, fractionalThreshold);
   cfg.set(detector::SEVERITY_FRACTION, severityLvl);
   cfg.set(detector::NEAR_FRACTION, nearLvl);
+  cfg.set(detector::QUORUM, quorum);
 
   return cfg;
 }

--- a/src/tests/filters/detectors/assurance_test.cpp
+++ b/src/tests/filters/detectors/assurance_test.cpp
@@ -26,18 +26,18 @@ using std::string;
  * under stable load.
  */
 TEST(AssuranceDetectorTest, StableSignal) {
-  const uint64_t WINDOWS_SIZE = 10;
-  const uint64_t CHECKPOINTS = 3;
+  const uint64_t WINDOWS_SIZE = 8;
+  const uint64_t MAX_CHECKPOINTS = 4;
   const double_t FRACTION_THRESHOLD = 0.5;
   const double_t SEVERITY_FRACTION = 0;
   const double_t NEAR_FRACTION = 0;
-  const uint64_t ITERATIONS = 100;
+  const uint64_t ITERATIONS = 30;
 
   AssuranceDetector assuranceDetector(
     Tag(QOS_CONTROLLER, "AssuranceDetector"),
     createAssuranceDetectorCfg(
         WINDOWS_SIZE,
-        CHECKPOINTS,
+        MAX_CHECKPOINTS,
         FRACTION_THRESHOLD,
         SEVERITY_FRACTION,
         NEAR_FRACTION));
@@ -57,19 +57,19 @@ TEST(AssuranceDetectorTest, StableSignal) {
 
 
 TEST(AssuranceDetectorTest, StableLoadOneBigDrop) {
-  const uint64_t WINDOWS_SIZE = 10;
-  const uint64_t CHECKPOINTS = 3;
+  const uint64_t WINDOWS_SIZE = 8;
+  const uint64_t MAX_CHECKPOINTS = 4;
   const double_t FRACTION_THRESHOLD = 0.5;
   const double_t SEVERITY_FRACTION = 1;
   const double_t NEAR_FRACTION = 0.1;
-  const uint64_t QUORUM = 2;
-  const uint64_t ITERATIONS = 100;
+  const double_t QUORUM = 0.5;
+  const uint64_t ITERATIONS = 30;
 
   AssuranceDetector assuranceDetector(
     Tag(QOS_CONTROLLER, "AssuranceDetector"),
     createAssuranceDetectorCfg(
       WINDOWS_SIZE,
-      CHECKPOINTS,
+      MAX_CHECKPOINTS,
       FRACTION_THRESHOLD,
       SEVERITY_FRACTION,
       NEAR_FRACTION,
@@ -79,7 +79,7 @@ TEST(AssuranceDetectorTest, StableLoadOneBigDrop) {
     SignalScenario(ITERATIONS)
       .use(math::const10Function)
       .use(new ZeroNoise())
-      .after(10).add(-5.0);
+      .after(10).add(-5.0);  // Introduce sudden drop.
 
   ITERATE_SIGNAL(signalGen) {
     Result<Detection> result =
@@ -95,19 +95,19 @@ TEST(AssuranceDetectorTest, StableLoadOneBigDrop) {
 
 
 TEST(AssuranceDetectorTest, StableLoadOneBigDropWithReset) {
-  const uint64_t WINDOWS_SIZE = 10;
-  const uint64_t CHECKPOINTS = 3;
+  const uint64_t WINDOWS_SIZE = 8;
+  const uint64_t MAX_CHECKPOINTS = 4;
   const double_t FRACTION_THRESHOLD = 0.5;
   const double_t SEVERITY_FRACTION = 1;
   const double_t NEAR_FRACTION = 0.1;
-  const uint64_t QUORUM = 2;
-  const uint64_t ITERATIONS = 16;
+  const double_t QUORUM = 0.50;
+  const uint64_t ITERATIONS = 30;
 
   AssuranceDetector assuranceDetector(
     Tag(QOS_CONTROLLER, "AssuranceDetector"),
     createAssuranceDetectorCfg(
       WINDOWS_SIZE,
-      CHECKPOINTS,
+      MAX_CHECKPOINTS,
       FRACTION_THRESHOLD,
       SEVERITY_FRACTION,
       NEAR_FRACTION,
@@ -117,13 +117,15 @@ TEST(AssuranceDetectorTest, StableLoadOneBigDropWithReset) {
     SignalScenario(ITERATIONS)
       .use(math::const10Function)
       .use(new ZeroNoise())
-      .after(10).add(-5.0);
+      .after(10).add(-5.0);  // Introduce sudden drop.
 
   ITERATE_SIGNAL(signalGen) {
     Result<Detection> result =
       assuranceDetector.processSample((*signalGen)());
 
-    if (signalGen.iteration >= 10 && signalGen.iteration < 20) {
+    // Detector should stop detecting after 4 iterations, since there are
+    // 4 checkpoints with quorum 3 (so we look in the past T-4 iterations).
+    if (signalGen.iteration >= 10 && signalGen.iteration < (10+4)) {
       EXPECT_SOME(result);
       assuranceDetector.reset();
     } else {
@@ -132,6 +134,162 @@ TEST(AssuranceDetectorTest, StableLoadOneBigDropWithReset) {
   }
 }
 
+
+TEST(AssuranceDetectorTest, StableLoadOneProgressiveDrop) {
+  const uint64_t WINDOWS_SIZE = 8;
+  const uint64_t MAX_CHECKPOINTS = 4;
+  const double_t FRACTION_THRESHOLD = 0.5;
+  const double_t SEVERITY_FRACTION = 1;
+  const double_t NEAR_FRACTION = 0.1;
+  const double_t QUORUM = 0.5;
+  const uint64_t ITERATIONS = 30;
+
+  AssuranceDetector assuranceDetector(
+    Tag(QOS_CONTROLLER, "AssuranceDetector"),
+    createAssuranceDetectorCfg(
+      WINDOWS_SIZE,
+      MAX_CHECKPOINTS,
+      FRACTION_THRESHOLD,
+      SEVERITY_FRACTION,
+      NEAR_FRACTION,
+      QUORUM));
+
+  SignalScenario signalGen =
+    SignalScenario(ITERATIONS)
+      .use(math::const10Function)
+      .use(new ZeroNoise())
+      .after(10).constantAdd(-1, 10);  // Introduce constant drop.
+
+  ITERATE_SIGNAL(signalGen) {
+    Result<Detection> result =
+      assuranceDetector.processSample((*signalGen)());
+
+    if (signalGen.iteration >= 15) {
+      EXPECT_SOME(result);
+    } else {
+      EXPECT_NONE(result);
+    }
+  }
+}
+
+
+TEST(AssuranceDetectorTest, StableLoadOneBigDropAndRecovery) {
+  const uint64_t WINDOWS_SIZE = 8;
+  const uint64_t MAX_CHECKPOINTS = 4;
+  const double_t FRACTION_THRESHOLD = 0.5;
+  const double_t SEVERITY_FRACTION = 1;
+  const double_t NEAR_FRACTION = 0.1;
+  const double_t QUORUM = 0.5;
+  const uint64_t ITERATIONS = 30;
+
+  AssuranceDetector assuranceDetector(
+    Tag(QOS_CONTROLLER, "AssuranceDetector"),
+    createAssuranceDetectorCfg(
+      WINDOWS_SIZE,
+      MAX_CHECKPOINTS,
+      FRACTION_THRESHOLD,
+      SEVERITY_FRACTION,
+      NEAR_FRACTION,
+      QUORUM));
+
+  SignalScenario signalGen =
+    SignalScenario(ITERATIONS)
+      .use(math::const10Function)
+      .use(new ZeroNoise())
+      .after(10).add(-5.0)  // Introduce sudden drop.
+      .after(5).constantAdd(1.0, 4);  // Introduce constant increase.
+
+  ITERATE_SIGNAL(signalGen) {
+    Result<Detection> result =
+      assuranceDetector.processSample((*signalGen)());
+
+    if (signalGen.iteration >= 10 && signalGen.iteration < 18) {
+      EXPECT_SOME(result);
+    } else {
+      EXPECT_NONE(result);
+    }
+  }
+}
+
+
+TEST(AssuranceDetectorTest, NoisyLoadOneBigDropLessCheckpoints) {
+  const uint64_t WINDOWS_SIZE = 8;
+  const double_t QUORUM = 0.70;
+  const uint64_t MAX_CHECKPOINTS = 4;
+
+  const double_t FRACTION_THRESHOLD = 0.5;
+  const double_t SEVERITY_FRACTION = 1;
+  const double_t NEAR_FRACTION = 0.1;
+  const uint64_t ITERATIONS = 30;
+  const uint64_t MAX_NOISE = 4;
+
+  AssuranceDetector assuranceDetector(
+    Tag(QOS_CONTROLLER, "AssuranceDetector"),
+    createAssuranceDetectorCfg(
+      WINDOWS_SIZE,
+      MAX_CHECKPOINTS,
+      FRACTION_THRESHOLD,
+      SEVERITY_FRACTION,
+      NEAR_FRACTION,
+      QUORUM));
+
+  SignalScenario signalGen =
+    SignalScenario(ITERATIONS)
+      .use(math::const10Function)
+      .use(new SymetricNoiseGenerator(MAX_NOISE))
+      .after(10).add(-5.0);  // Introduce sudden drop.
+
+  ITERATE_SIGNAL(signalGen) {
+    Result<Detection> result =
+      assuranceDetector.processSample((*signalGen)());
+
+    if (signalGen.iteration >= 11) {
+      EXPECT_SOME(result);
+    } else {
+      EXPECT_NONE(result);
+    }
+  }
+}
+
+
+TEST(AssuranceDetectorTest, NoisyLoadOneBigDropMoreCheckpoints) {
+  const uint64_t WINDOWS_SIZE = 16;
+  const uint64_t MAX_CHECKPOINTS = 5;
+  const double_t QUORUM = 0.70;
+
+  const double_t FRACTION_THRESHOLD = 0.5;
+  const double_t SEVERITY_FRACTION = 1;
+  const double_t NEAR_FRACTION = 0.1;
+  const uint64_t ITERATIONS = 30;
+  const uint64_t MAX_NOISE = 4;
+
+  AssuranceDetector assuranceDetector(
+    Tag(QOS_CONTROLLER, "AssuranceDetector"),
+    createAssuranceDetectorCfg(
+      WINDOWS_SIZE,
+      MAX_CHECKPOINTS,
+      FRACTION_THRESHOLD,
+      SEVERITY_FRACTION,
+      NEAR_FRACTION,
+      QUORUM));
+
+  SignalScenario signalGen =
+    SignalScenario(ITERATIONS)
+      .use(math::const10Function)
+      .use(new SymetricNoiseGenerator(MAX_NOISE))
+      .after(10).add(-5.0);  // Introduce sudden drop.
+
+  ITERATE_SIGNAL(signalGen) {
+    Result<Detection> result =
+      assuranceDetector.processSample((*signalGen)());
+
+    if (signalGen.iteration >= 11) {
+      EXPECT_SOME(result);
+    } else {
+      EXPECT_NONE(result);
+    }
+  }
+}
 
 }  //  namespace tests
 }  //  namespace serenity

--- a/src/tests/filters/detectors/assurance_test.cpp
+++ b/src/tests/filters/detectors/assurance_test.cpp
@@ -1,0 +1,138 @@
+#include <list>
+#include <string>
+
+#include "filters/detectors/assurance.hpp"
+
+#include "gtest/gtest.h"
+
+#include "pwave/scenario.hpp"
+
+#include "stout/gtest.hpp"
+
+#include "serenity/data_utils.hpp"
+
+#include "tests/common/config_helper.hpp"
+
+namespace mesos {
+namespace serenity {
+namespace tests {
+
+using namespace pwave;  // NOLINT(build/namespaces)
+
+using std::string;
+
+/**
+ * Check if AssuranceDetector won't detect any change point
+ * under stable load.
+ */
+TEST(AssuranceDetectorTest, StableSignal) {
+  const uint64_t WINDOWS_SIZE = 10;
+  const uint64_t CHECKPOINTS = 3;
+  const double_t FRACTION_THRESHOLD = 0.5;
+  const double_t SEVERITY_FRACTION = 0;
+  const double_t NEAR_FRACTION = 0;
+  const uint64_t ITERATIONS = 100;
+
+  AssuranceDetector assuranceDetector(
+    Tag(QOS_CONTROLLER, "AssuranceDetector"),
+    createAssuranceDetectorCfg(
+        WINDOWS_SIZE,
+        CHECKPOINTS,
+        FRACTION_THRESHOLD,
+        SEVERITY_FRACTION,
+        NEAR_FRACTION));
+
+  SignalScenario signalGen =
+    SignalScenario(ITERATIONS)
+      .use(math::const10Function)
+      .use(new ZeroNoise());
+
+  ITERATE_SIGNAL(signalGen) {
+    Result<Detection> result =
+      assuranceDetector.processSample((*signalGen)());
+
+    EXPECT_NONE(result);
+  }
+}
+
+
+TEST(AssuranceDetectorTest, StableLoadOneBigDrop) {
+  const uint64_t WINDOWS_SIZE = 10;
+  const uint64_t CHECKPOINTS = 3;
+  const double_t FRACTION_THRESHOLD = 0.5;
+  const double_t SEVERITY_FRACTION = 1;
+  const double_t NEAR_FRACTION = 0.1;
+  const uint64_t QUORUM = 2;
+  const uint64_t ITERATIONS = 100;
+
+  AssuranceDetector assuranceDetector(
+    Tag(QOS_CONTROLLER, "AssuranceDetector"),
+    createAssuranceDetectorCfg(
+      WINDOWS_SIZE,
+      CHECKPOINTS,
+      FRACTION_THRESHOLD,
+      SEVERITY_FRACTION,
+      NEAR_FRACTION,
+      QUORUM));
+
+  SignalScenario signalGen =
+    SignalScenario(ITERATIONS)
+      .use(math::const10Function)
+      .use(new ZeroNoise())
+      .after(10).add(-5.0);
+
+  ITERATE_SIGNAL(signalGen) {
+    Result<Detection> result =
+      assuranceDetector.processSample((*signalGen)());
+
+    if (signalGen.iteration >= 10) {
+      EXPECT_SOME(result);
+    } else {
+      EXPECT_NONE(result);
+    }
+  }
+}
+
+
+TEST(AssuranceDetectorTest, StableLoadOneBigDropWithReset) {
+  const uint64_t WINDOWS_SIZE = 10;
+  const uint64_t CHECKPOINTS = 3;
+  const double_t FRACTION_THRESHOLD = 0.5;
+  const double_t SEVERITY_FRACTION = 1;
+  const double_t NEAR_FRACTION = 0.1;
+  const uint64_t QUORUM = 2;
+  const uint64_t ITERATIONS = 16;
+
+  AssuranceDetector assuranceDetector(
+    Tag(QOS_CONTROLLER, "AssuranceDetector"),
+    createAssuranceDetectorCfg(
+      WINDOWS_SIZE,
+      CHECKPOINTS,
+      FRACTION_THRESHOLD,
+      SEVERITY_FRACTION,
+      NEAR_FRACTION,
+      QUORUM));
+
+  SignalScenario signalGen =
+    SignalScenario(ITERATIONS)
+      .use(math::const10Function)
+      .use(new ZeroNoise())
+      .after(10).add(-5.0);
+
+  ITERATE_SIGNAL(signalGen) {
+    Result<Detection> result =
+      assuranceDetector.processSample((*signalGen)());
+
+    if (signalGen.iteration >= 10 && signalGen.iteration < 20) {
+      EXPECT_SOME(result);
+      assuranceDetector.reset();
+    } else {
+      EXPECT_NONE(result);
+    }
+  }
+}
+
+
+}  //  namespace tests
+}  //  namespace serenity
+}  //  namespace mesos

--- a/src/tests/observers/qos_correction_test.cpp
+++ b/src/tests/observers/qos_correction_test.cpp
@@ -10,10 +10,10 @@
 #include "messages/serenity.hpp"
 
 #include "filters/executor_age.hpp"
-#include "filters/pr_executor_pass.hpp"
 
 #include "observers/qos_correction.hpp"
 
+#include "serenity/resource_helper.hpp"
 #include "serenity/wid.hpp"
 
 #include "tests/common/usage_helper.hpp"
@@ -52,7 +52,8 @@ TEST(HelperFunctionsTest, filterPrExecutorsEval) {
   ResourceUsage usage;
   usage.CopyFrom(usages.get().resource_usage(0));
 
-  std::list<ResourceUsage_Executor> ret = filterPrExecutors(usage);
+  std::list<ResourceUsage_Executor> ret =
+    DividedResourceUsage::filterPrExecutors(usage);
 
   ASSERT_EQ(3u, ret.size());
 

--- a/src/tests/observers/qos_correction_test.cpp
+++ b/src/tests/observers/qos_correction_test.cpp
@@ -10,6 +10,7 @@
 #include "messages/serenity.hpp"
 
 #include "filters/executor_age.hpp"
+#include "filters/pr_executor_pass.hpp"
 
 #include "observers/qos_correction.hpp"
 


### PR DESCRIPTION
Main rationale for this change is to improve revocation pipeline, so:

1. Detector:

        /**
         * Dynamic implementation of sequential change point detection.
         *
         * There is no warm-up phase - values starts as DEFAULT_START_VALUE.
         * Algorithm steps:
         * - Fetch several basePoints depending on parameters e.g T-1, T-2, T-4, T-8.
         * - Make a voting within all basePoints(checkpoints). Drop will be
         *    detected when dropVotes will be >= Quorum number. Checkpoint will vote
         *    on drop when drop will be higher than value specified in
         *    FRACTIONAL_THRESHOLD.
         * - There are three checkpoint stats in logging:
         *   a) [-] vote on drop.
         *   b) [~] value below checkpoint, but not significant.
         *   c) [+] value is bigger than checkpoint.
         * - When drop appears, start tracking mean value of drop from all basePoints
         *  which voted on drop.
         * - When tracking is active, create contentions until the signal recover or
         *   detector is reset externally.
         *
         *  We can use EMA value as input for better results.
         */


2. Decider -> RevocationStrategy
  - Moved resposibility of Cooldown phase to revocation strategy.

@nqn, @skonefal Describtion updated.